### PR TITLE
Fix RemoveLinkAsync

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
@@ -313,11 +313,15 @@ namespace Dotnet.AzureDevOps.Core.Boards
         public async Task RemoveLinkAsync(int workItemId, string linkUrl, CancellationToken cancellationToken = default)
         {
             WorkItem? item = await GetWorkItemAsync(workItemId, cancellationToken);
-            if(item?.Relations == null)
+            if (item?.Relations == null)
                 return;
 
-            int index = (item.Relations as List<WorkItemRelation>)?.FindIndex(r => r.Url == linkUrl) ?? -1;
-            if(index < 0)
+            WorkItemRelation? relation = item.Relations.FirstOrDefault(r => r.Url == linkUrl);
+            if (relation == null)
+                return;
+
+            int index = item.Relations.IndexOf(relation);
+            if (index < 0)
                 return;
 
             var patch = new JsonPatchDocument


### PR DESCRIPTION
## Summary
- handle removal of links from WorkItem using IList

## Testing
- `dotnet build` *(fails: project path not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870280ffd50832caa283909b4b44dff