### PR TITLE
Move project settings features

### DIFF
--- a/Dotnet.AzureDevOps.sln
+++ b/Dotnet.AzureDevOps.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Core.Ove
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Core.Artifacts", "src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Artifacts\Dotnet.AzureDevOps.Core.Artifacts.csproj", "{F5B68A31-3481-468C-859B-6E54EF7938D9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Core.ProjectSettings", "src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.ProjectSettings\Dotnet.AzureDevOps.Core.ProjectSettings.csproj", "{E19DD6B0-5673-460C-98FC-2E4FDE9333AC}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Repos.Tests", "test\unit.tests\Dotnet.AzureDevOps.Repos.Tests\Dotnet.AzureDevOps.Repos.Tests.csproj", "{9233EFFE-7DB8-495E-940F-D8119E2827FA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Boards.Tests", "test\unit.tests\Dotnet.AzureDevOps.Boards.Tests\Dotnet.AzureDevOps.Boards.Tests.csproj", "{77EDDE45-F965-40B4-BA8F-BD6E88F1842C}"
@@ -42,6 +44,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzuredevOps.Pipeline.IntegrationTests", "test\integration.tests\Dotnet.AzuredevOps.Pipeline.IntegrationTests\Dotnet.AzuredevOps.Pipeline.IntegrationTests.csproj", "{30F38FF3-D8AB-4BEB-BC0A-1137C9AE21AC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzuredevOps.TestPlans.IntegrationTests", "test\integration.tests\Dotnet.AzuredevOps.TestPlans.IntegrationTests\Dotnet.AzuredevOps.TestPlans.IntegrationTests.csproj", "{D3BEDBBE-41C8-21C8-14B9-126F9121DF70}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests", "test\integration.tests\Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests\Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests.csproj", "{14C7C54E-CA68-4022-B6DE-C57324C8DB89}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "integration.tests", "integration.tests", "{5A3D3D52-1324-4B57-8CE0-26C7EBC7331A}"
 EndProject
@@ -100,6 +104,10 @@ Global
 		{F5B68A31-3481-468C-859B-6E54EF7938D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5B68A31-3481-468C-859B-6E54EF7938D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5B68A31-3481-468C-859B-6E54EF7938D9}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E19DD6B0-5673-460C-98FC-2E4FDE9333AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E19DD6B0-5673-460C-98FC-2E4FDE9333AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E19DD6B0-5673-460C-98FC-2E4FDE9333AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E19DD6B0-5673-460C-98FC-2E4FDE9333AC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9233EFFE-7DB8-495E-940F-D8119E2827FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9233EFFE-7DB8-495E-940F-D8119E2827FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9233EFFE-7DB8-495E-940F-D8119E2827FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -152,6 +160,10 @@ Global
 		{D3BEDBBE-41C8-21C8-14B9-126F9121DF70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3BEDBBE-41C8-21C8-14B9-126F9121DF70}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3BEDBBE-41C8-21C8-14B9-126F9121DF70}.Release|Any CPU.Build.0 = Release|Any CPU
+                {14C7C54E-CA68-4022-B6DE-C57324C8DB89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {14C7C54E-CA68-4022-B6DE-C57324C8DB89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {14C7C54E-CA68-4022-B6DE-C57324C8DB89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {14C7C54E-CA68-4022-B6DE-C57324C8DB89}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CCCA55CA-BB84-FCAF-A594-E83C79EF83DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CCCA55CA-BB84-FCAF-A594-E83C79EF83DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCCA55CA-BB84-FCAF-A594-E83C79EF83DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -172,6 +184,7 @@ Global
 		{35054ABA-FEB8-4FA9-BB59-F281FBB02BE7} = {B43ED0CE-E893-4D77-AD74-6913881416AF}
 		{9F36A7C7-0A82-4F64-82F6-499D0F0E0D36} = {B43ED0CE-E893-4D77-AD74-6913881416AF}
 		{F5B68A31-3481-468C-859B-6E54EF7938D9} = {B43ED0CE-E893-4D77-AD74-6913881416AF}
+                {E19DD6B0-5673-460C-98FC-2E4FDE9333AC} = {B43ED0CE-E893-4D77-AD74-6913881416AF}
 		{9233EFFE-7DB8-495E-940F-D8119E2827FA} = {40238C68-3450-4C9D-B467-9D0BBB236271}
 		{77EDDE45-F965-40B4-BA8F-BD6E88F1842C} = {40238C68-3450-4C9D-B467-9D0BBB236271}
 		{19499305-2957-4FBE-8698-50D87422CAE0} = {40238C68-3450-4C9D-B467-9D0BBB236271}
@@ -185,6 +198,7 @@ Global
 		{6C2FA7E9-ADCA-4974-9BAD-A07FC1F99533} = {5A3D3D52-1324-4B57-8CE0-26C7EBC7331A}
 		{30F38FF3-D8AB-4BEB-BC0A-1137C9AE21AC} = {5A3D3D52-1324-4B57-8CE0-26C7EBC7331A}
 		{D3BEDBBE-41C8-21C8-14B9-126F9121DF70} = {5A3D3D52-1324-4B57-8CE0-26C7EBC7331A}
+                {14C7C54E-CA68-4022-B6DE-C57324C8DB89} = {5A3D3D52-1324-4B57-8CE0-26C7EBC7331A}
 		{5A3D3D52-1324-4B57-8CE0-26C7EBC7331A} = {2D495C55-779C-4B15-8A2F-252EEB79B860}
 		{7D77AE33-A2A7-4595-ACC6-15E56B1E836F} = {2D495C55-779C-4B15-8A2F-252EEB79B860}
 		{40238C68-3450-4C9D-B467-9D0BBB236271} = {2D495C55-779C-4B15-8A2F-252EEB79B860}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
@@ -23,6 +23,9 @@ namespace Dotnet.AzureDevOps.Core.Boards
         Task<object?> GetCustomFieldAsync(int workItemId, string fieldName, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkItemUpdate>> GetHistoryAsync(int workItemId, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkItemRelation>> GetLinksAsync(int workItemId, CancellationToken cancellationToken = default);
+        Task<List<BoardReference>> ListBoardsAsync(TeamContext teamContext, object? userState = null, CancellationToken cancellationToken = default);
+        Task<TeamSettingsIteration> GetTeamIterationAsync(TeamContext teamContext, Guid iterationId, object? userState = null, CancellationToken cancellationToken = default);
+        Task<List<TeamSettingsIteration>> GetTeamIterationsAsync(TeamContext teamContext, string timeframe, object? userState = null, CancellationToken cancellationToken = default);
         Task<WorkItem?> GetWorkItemAsync(int workItemId, CancellationToken cancellationToken = default);
         Task<int> GetWorkItemCountAsync(string wiql, CancellationToken cancellationToken = default);
         Task<TeamFieldValues> ListAreasAsync(TeamContext teamContext, CancellationToken cancellationToken = default);

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using Dotnet.AzureDevOps.Core.Boards.Options;
 using Dotnet.AzureDevOps.Core.Common;
 using Microsoft.TeamFoundation.Core.WebApi;
-using Microsoft.TeamFoundation.Core.WebApi.Types;
 using Microsoft.TeamFoundation.Work.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
@@ -22,7 +21,6 @@ namespace Dotnet.AzureDevOps.Core.Boards
         private readonly string _projectName;
         private readonly WorkItemTrackingHttpClient _workItemClient;
         private readonly WorkHttpClient _workClient;
-        private readonly TeamHttpClient _teamClient;
         private readonly string _personalAccessToken;
 
         public WorkItemsClient(string organizationUrl, string projectName, string personalAccessToken)
@@ -35,7 +33,6 @@ namespace Dotnet.AzureDevOps.Core.Boards
             var connection = new VssConnection(new Uri(_organizationUrl), credentials);
             _workItemClient = connection.GetClient<WorkItemTrackingHttpClient>();
             _workClient = connection.GetClient<WorkHttpClient>();
-            _teamClient = connection.GetClient<TeamHttpClient>();
         }
 
         public Task<int?> CreateEpicAsync(WorkItemCreateOptions workItemCreateOptions, CancellationToken cancellationToken = default) =>
@@ -341,6 +338,15 @@ namespace Dotnet.AzureDevOps.Core.Boards
             return (IReadOnlyList<WorkItemRelation>)(item?.Relations ?? []);
         }
 
+        public Task<List<BoardReference>> ListBoardsAsync(TeamContext teamContext, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetBoardsAsync(teamContext, userState, cancellationToken);
+
+        public Task<TeamSettingsIteration> GetTeamIterationAsync(TeamContext teamContext, Guid iterationId, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetTeamIterationAsync(teamContext, iterationId, userState, cancellationToken);
+
+        public Task<List<TeamSettingsIteration>> GetTeamIterationsAsync(TeamContext teamContext, string timeframe, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetTeamIterationsAsync(teamContext, timeframe, userState, cancellationToken);
+
         public Task<List<BoardColumn>> ListBoardColumnsAsync(TeamContext teamContext, Guid board, object? userState = null, CancellationToken cancellationToken = default)
             => _workClient.GetBoardColumnsAsync(teamContext, board.ToString(), userState, cancellationToken: cancellationToken);
 
@@ -397,143 +403,5 @@ namespace Dotnet.AzureDevOps.Core.Boards
             }
         }
 
-        public async Task<bool> CreateTeamAsync(string teamName, string teamDescription)
-        {
-            var newTeam = new WebApiTeam()
-            {
-                Name = teamName,
-                Description = teamDescription
-            };
-
-            try
-            {
-                WebApiTeam createdTeam = await _teamClient.CreateTeamAsync(newTeam, _projectName);
-                return createdTeam.Description == teamDescription && createdTeam.Name == teamName;
-            }
-            catch(Exception)
-            {
-                return false;
-            }
-        }
-
-        public async Task<Guid> GetTeamIdAsync(string teamName)
-        {
-            try
-            {
-                WebApiTeam team = await _teamClient.GetTeamAsync(_projectName, teamName);
-                return team.Id;
-            }
-            catch(Exception)
-            {
-                return Guid.Empty;
-            }
-        }
-
-        public async Task<bool> UpdateTeamDescriptionAsync(string teamName, string newDescription)
-        {
-            try
-            {
-                WebApiTeam team = await _teamClient.GetTeamAsync(_projectName, teamName);
-
-                var updatedTeam = new WebApiTeam()
-                {
-                    Description = newDescription
-                };
-
-                WebApiTeam webApiTeam = await _teamClient.UpdateTeamAsync(updatedTeam, _projectName, team.Id.ToString());
-
-                return webApiTeam.Description == newDescription && webApiTeam.Name == teamName;
-            }
-            catch(Exception)
-            {
-                return false;
-            }
-        }
-
-        public async Task<List<BoardReference>> ListBoardsAsync(TeamContext teamContext, object? userState = null, CancellationToken cancellationToken = default) =>
-            await _workClient.GetBoardsAsync(teamContext, userState, cancellationToken);
-
-        public async Task<TeamSettingsIteration> GetTeamIterationAsync(TeamContext teamContext, Guid iterationId, object? userState = null, CancellationToken cancellationToken = default) =>
-            await _workClient.GetTeamIterationAsync(teamContext, iterationId, userState, cancellationToken);
-
-        public async Task<List<TeamSettingsIteration>> GetTeamIterationsAsync(TeamContext teamContext, string timeframe, object? userState = null, CancellationToken cancellationToken = default) =>
-            await _workClient.GetTeamIterationsAsync(teamContext, timeframe, userState, cancellationToken);
-
-        /// <summary>
-        /// Deletes a team from the specified project in the organization. Doesn't work, Gives a 500 so far!!!
-        /// </summary>
-        /// <remarks>This method sends an HTTP DELETE request to the organization's API to remove the
-        /// specified team. Ensure that the provided <paramref name="teamGuid"/> corresponds to an existing
-        /// team.</remarks>
-        /// <param name="teamGuid">The unique identifier of the team to delete.</param>
-        /// <returns><see langword="true"/> if the team was successfully deleted; otherwise, <see langword="false"/>.</returns>
-        public async Task<bool> DeleteTeamAsync(Guid teamGuid)
-        {
-            try
-            {
-                using var client = new HttpClient();
-                string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-
-                string url = $"{_organizationUrl}/_apis/projects/{_projectName}/teams/{teamGuid}?api-version={Constants.ApiVersion}";
-
-                HttpResponseMessage response = await client.DeleteAsync(url);
-
-                return response.IsSuccessStatusCode;
-            }
-            catch(Exception)
-            {
-                return false;
-            }
-        }
-
-        public async Task<bool> CreateInheritedProcessAsync(
-            string newProcessName,
-            string description,
-            string baseProcessName // e.g. "Agile", "Scrum", "CMMI"
-            )
-        {
-            string parentProcessId = baseProcessName.ToLower() switch
-            {
-                "agile" => "adcc42ab-9882-485e-a3ed-7678f01f66bc",
-                "scrum" => "6b724908-ef14-45cf-84f8-768b5384da45",
-                "cmmi" => "27450541-8e31-4150-9947-dc59f998fc01",
-                _ => throw new ArgumentException("Unsupported base process name")
-            };
-
-            string url = $"{_organizationUrl}/_apis/work/processes?api-version={Constants.ApiVersion}";
-
-            using var client = new HttpClient();
-
-            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-            var payload = new
-            {
-                name = newProcessName,
-                description = description,
-                parentProcessTypeId = parentProcessId
-            };
-
-            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-
-            HttpResponseMessage response = await client.PostAsync(url, content);
-
-            return response.IsSuccessStatusCode;
-        }
-
-        public async Task<bool> DeleteInheritedProcessAsync(string processId)
-        {
-            string url = $"{_organizationUrl}/_apis/work/processadmin/processes/{processId}?api-version=7.1-preview.1";
-
-            using var client = new HttpClient();
-            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-
-            HttpResponseMessage response = await client.DeleteAsync(url);
-
-            return response.IsSuccessStatusCode;
-        }
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/Dotnet.AzureDevOps.Core.ProjectSettings.csproj
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/Dotnet.AzureDevOps.Core.ProjectSettings.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet.AzureDevOps.Core.Common\Dotnet.AzureDevOps.Core.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/IProjectSettingsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/IProjectSettingsClient.cs
@@ -1,0 +1,14 @@
+using Microsoft.TeamFoundation.Core.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.ProjectSettings
+{
+    public interface IProjectSettingsClient
+    {
+        Task<bool> CreateTeamAsync(string teamName, string teamDescription);
+        Task<Guid> GetTeamIdAsync(string teamName);
+        Task<bool> UpdateTeamDescriptionAsync(string teamName, string newDescription);
+        Task<bool> DeleteTeamAsync(Guid teamGuid);
+        Task<bool> CreateInheritedProcessAsync(string newProcessName, string description, string baseProcessName);
+        Task<bool> DeleteInheritedProcessAsync(string processId);
+    }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
@@ -1,0 +1,147 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Dotnet.AzureDevOps.Core.Common;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.ProjectSettings
+{
+    public class ProjectSettingsClient : IProjectSettingsClient
+    {
+        private readonly string _organizationUrl;
+        private readonly string _projectName;
+        private readonly TeamHttpClient _teamClient;
+        private readonly string _personalAccessToken;
+
+        public ProjectSettingsClient(string organizationUrl, string projectName, string personalAccessToken)
+        {
+            _organizationUrl = organizationUrl;
+            _projectName = projectName;
+            _personalAccessToken = personalAccessToken;
+
+            var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
+            var connection = new VssConnection(new Uri(_organizationUrl), credentials);
+            _teamClient = connection.GetClient<TeamHttpClient>();
+        }
+
+        public async Task<bool> CreateTeamAsync(string teamName, string teamDescription)
+        {
+            var newTeam = new WebApiTeam()
+            {
+                Name = teamName,
+                Description = teamDescription
+            };
+
+            try
+            {
+                WebApiTeam createdTeam = await _teamClient.CreateTeamAsync(newTeam, _projectName);
+                return createdTeam.Description == teamDescription && createdTeam.Name == teamName;
+            }
+            catch(Exception)
+            {
+                return false;
+            }
+        }
+
+        public async Task<Guid> GetTeamIdAsync(string teamName)
+        {
+            try
+            {
+                WebApiTeam team = await _teamClient.GetTeamAsync(_projectName, teamName);
+                return team.Id;
+            }
+            catch(Exception)
+            {
+                return Guid.Empty;
+            }
+        }
+
+        public async Task<bool> UpdateTeamDescriptionAsync(string teamName, string newDescription)
+        {
+            try
+            {
+                WebApiTeam team = await _teamClient.GetTeamAsync(_projectName, teamName);
+
+                var updatedTeam = new WebApiTeam()
+                {
+                    Description = newDescription
+                };
+
+                WebApiTeam webApiTeam = await _teamClient.UpdateTeamAsync(updatedTeam, _projectName, team.Id.ToString());
+
+                return webApiTeam.Description == newDescription && webApiTeam.Name == teamName;
+            }
+            catch(Exception)
+            {
+                return false;
+            }
+        }
+
+        public async Task<bool> DeleteTeamAsync(Guid teamGuid)
+        {
+            try
+            {
+                using var client = new HttpClient();
+                string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+                string url = $"{_organizationUrl}/_apis/projects/{_projectName}/teams/{teamGuid}?api-version={Constants.ApiVersion}";
+
+                HttpResponseMessage response = await client.DeleteAsync(url);
+
+                return response.IsSuccessStatusCode;
+            }
+            catch(Exception)
+            {
+                return false;
+            }
+        }
+
+        public async Task<bool> CreateInheritedProcessAsync(string newProcessName, string description, string baseProcessName)
+        {
+            string parentProcessId = baseProcessName.ToLower() switch
+            {
+                "agile" => "adcc42ab-9882-485e-a3ed-7678f01f66bc",
+                "scrum" => "6b724908-ef14-45cf-84f8-768b5384da45",
+                "cmmi" => "27450541-8e31-4150-9947-dc59f998fc01",
+                _ => throw new ArgumentException("Unsupported base process name")
+            };
+
+            string url = $"{_organizationUrl}/_apis/work/processes?api-version={Constants.ApiVersion}";
+
+            using var client = new HttpClient();
+
+            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var payload = new
+            {
+                name = newProcessName,
+                description = description,
+                parentProcessTypeId = parentProcessId
+            };
+
+            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+            HttpResponseMessage response = await client.PostAsync(url, content);
+
+            return response.IsSuccessStatusCode;
+        }
+
+        public async Task<bool> DeleteInheritedProcessAsync(string processId)
+        {
+            string url = $"{_organizationUrl}/_apis/work/processadmin/processes/{processId}?api-version=7.1-preview.1";
+
+            using var client = new HttpClient();
+            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+            HttpResponseMessage response = await client.DeleteAsync(url);
+
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -3,10 +3,8 @@ using Dotnet.AzureDevOps.Core.Boards;
 using Dotnet.AzureDevOps.Core.Boards.Options;
 using Dotnet.AzureDevOps.Tests.Common;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
-using Microsoft.TeamFoundation.Work.WebApi;
 using System.IO;
 using System.Linq;
-using Microsoft.TeamFoundation.Core.WebApi.Types;
 
 namespace Dotnet.AzureDevOps.Boards.IntegrationTests
 {
@@ -522,48 +520,6 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
             Assert.DoesNotContain(after, l => l.Url == linkUrl);
         }
 
-        /// <summary>
-        /// Retrieve board configuration pieces.
-        /// </summary>
-        [Fact]
-        public async Task BoardConfiguration_SucceedsAsync()
-        {
-            string testTeamName = "Dotnet.McpIntegrationTest Team";
-            var teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName, testTeamName);
-            string boardName = $"{_azureDevOpsConfiguration.ProjectName} Team";
-             await _workItemsClient.CreateTeamAsync(testTeamName, "description1");
-            await _workItemsClient.UpdateTeamDescriptionAsync(testTeamName, "description2");
-            List<BoardReference> boardReferenceList = await _workItemsClient.ListBoardsAsync(teamContext, boardName);
-            List<TeamSettingsIteration> iterations = await _workItemsClient.GetTeamIterationsAsync(teamContext, "");
-            
-            IReadOnlyList<BoardColumn> cols = await _workItemsClient.ListBoardColumnsAsync(teamContext, boardReferenceList[0].Id, testTeamName);
-            await _workItemsClient.DeleteTeamAsync(await _workItemsClient.GetTeamIdAsync(testTeamName));
-
-            Assert.NotNull(cols);
-
-            IReadOnlyList<TeamSettingsIteration> iterationList = await _workItemsClient.ListIterationsAsync(teamContext, "current", _azureDevOpsConfiguration.ProjectName);
-            Assert.NotNull(iterations);
-            Assert.NotNull(iterationList);
-
-            TeamFieldValues areas = await _workItemsClient.ListAreasAsync(teamContext);
-            Assert.NotNull(areas);
-        }
-
-        /// <summary>
-        /// Get analytics for a WIQL query.
-        /// </summary>
-        [Fact]
-        public async Task Analytics_SucceedsAsync()
-        {
-            string wiql = "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project";
-            int count = await _workItemsClient.GetWorkItemCountAsync(wiql);
-            Assert.True(count >= 0);
-        }
-
-        /// <summary>
-        /// Update multiple work items in bulk.
-        /// </summary>
-        [Fact]
         public async Task BulkEdit_SucceedsAsync()
         {
             int? a = await _workItemsClient.CreateTaskAsync(new WorkItemCreateOptions { Title = "Bulk 1", Tags = "IntegrationTest;Bulk" });

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests.csproj
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.ProjectSettings\Dotnet.AzureDevOps.Core.ProjectSettings.csproj" />
+    <ProjectReference Include="..\..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Boards\Dotnet.AzureDevOps.Core.Boards.csproj" />
+    <ProjectReference Include="..\..\Dotnet.AzureDevOps.Tests.Common\Dotnet.AzureDevOps.Tests.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using Dotnet.AzureDevOps.Core.Boards;
+using Dotnet.AzureDevOps.Core.ProjectSettings;
+using Dotnet.AzureDevOps.Tests.Common;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.TeamFoundation.Work.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests
+{
+    [ExcludeFromCodeCoverage]
+    public class DotnetAzureDevOpsProjectSettingsIntegrationTests : IAsyncLifetime
+    {
+        private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
+        private readonly ProjectSettingsClient _projectSettingsClient;
+        private readonly WorkItemsClient _workItemsClient;
+
+        public DotnetAzureDevOpsProjectSettingsIntegrationTests()
+        {
+            _azureDevOpsConfiguration = new AzureDevOpsConfiguration();
+            _projectSettingsClient = new ProjectSettingsClient(
+                _azureDevOpsConfiguration.OrganisationUrl,
+                _azureDevOpsConfiguration.ProjectName,
+                _azureDevOpsConfiguration.PersonalAccessToken);
+            _workItemsClient = new WorkItemsClient(
+                _azureDevOpsConfiguration.OrganisationUrl,
+                _azureDevOpsConfiguration.ProjectName,
+                _azureDevOpsConfiguration.PersonalAccessToken);
+        }
+
+        [Fact]
+        public async Task TeamAndBoardConfiguration_SucceedsAsync()
+        {
+            string testTeamName = "Dotnet.McpIntegrationTest Team";
+            var teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName, testTeamName);
+            string boardName = $"{_azureDevOpsConfiguration.ProjectName} Team";
+            await _projectSettingsClient.CreateTeamAsync(testTeamName, "description1");
+            await _projectSettingsClient.UpdateTeamDescriptionAsync(testTeamName, "description2");
+            List<BoardReference> boardReferenceList = await _workItemsClient.ListBoardsAsync(teamContext, boardName);
+            List<TeamSettingsIteration> iterations = await _workItemsClient.GetTeamIterationsAsync(teamContext, "");
+
+            IReadOnlyList<BoardColumn> cols = await _workItemsClient.ListBoardColumnsAsync(teamContext, boardReferenceList[0].Id, testTeamName);
+            await _projectSettingsClient.DeleteTeamAsync(await _projectSettingsClient.GetTeamIdAsync(testTeamName));
+
+            Assert.NotNull(cols);
+
+            IReadOnlyList<TeamSettingsIteration> iterationList = await _workItemsClient.ListIterationsAsync(teamContext, "current", _azureDevOpsConfiguration.ProjectName);
+            Assert.NotNull(iterations);
+            Assert.NotNull(iterationList);
+
+            TeamFieldValues areas = await _workItemsClient.ListAreasAsync(teamContext);
+            Assert.NotNull(areas);
+        }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+}

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/xunit.runner.json
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettingsIntegatioTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "parallelizeAssembly": true,
+    "parallelizeTestCollections": false,
+    "maxParallelThreads": 1
+}


### PR DESCRIPTION
## Summary
- add new `ProjectSettings` client library
- migrate team and process operations into `ProjectSettingsClient`
- move board configuration test to a new integration test project
- update `WorkItemsClient` to focus on boards
- register new projects in the solution
- restore board listing methods

## Testing
- ❌ `dotnet test` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870323f5688832cb5f650d372fd6fe8