### PR TITLE
Expose new boards and project settings functionality

### DIFF
--- a/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Pipelines\Dotnet.AzureDevOps.Core.Pipelines.csproj" />
     <ProjectReference Include="..\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Repos\Dotnet.AzureDevOps.Core.Repos.csproj" />
     <ProjectReference Include="..\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.TestPlans\Dotnet.AzureDevOps.Core.TestPlans.csproj" />
+    <ProjectReference Include="..\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.ProjectSettings\Dotnet.AzureDevOps.Core.ProjectSettings.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
@@ -168,6 +168,27 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools
             return client.ListBoardColumnsAsync(teamContext, boardId, userState);
         }
 
+        [McpServerTool, Description("Lists boards for a team.")]
+        public static Task<List<BoardReference>> ListBoardsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.ListBoardsAsync(teamContext, userState);
+        }
+
+        [McpServerTool, Description("Gets a specific team iteration.")]
+        public static Task<TeamSettingsIteration> GetTeamIterationAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, Guid iterationId, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.GetTeamIterationAsync(teamContext, iterationId, userState);
+        }
+
+        [McpServerTool, Description("Lists iterations for a team with a timeframe filter.")]
+        public static Task<List<TeamSettingsIteration>> GetTeamIterationsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, string timeframe, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.GetTeamIterationsAsync(teamContext, timeframe, userState);
+        }
+
         [McpServerTool, Description("Lists iterations for a team.")]
         public static Task<List<TeamSettingsIteration>> ListIterationsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, string? timeFrame = null, object? userState = null)
         {

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Dotnet.AzureDevOps.Core.ProjectSettings;
+using Microsoft.TeamFoundation.Core.WebApi;
+using ModelContextProtocol.Server;
+
+namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
+
+/// <summary>
+/// Exposes project and process management operations through Model Context Protocol.
+/// </summary>
+[McpServerToolType]
+public class ProjectSettingsTools
+{
+    private static ProjectSettingsClient CreateClient(string organizationUrl, string projectName, string personalAccessToken)
+        => new(organizationUrl, projectName, personalAccessToken);
+
+    [McpServerTool, Description("Creates a new team in the project.")]
+    public static Task<bool> CreateTeamAsync(string organizationUrl, string projectName, string personalAccessToken, string teamName, string teamDescription)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.CreateTeamAsync(teamName, teamDescription);
+    }
+
+    [McpServerTool, Description("Gets a team's identifier by name.")]
+    public static Task<Guid> GetTeamIdAsync(string organizationUrl, string projectName, string personalAccessToken, string teamName)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetTeamIdAsync(teamName);
+    }
+
+    [McpServerTool, Description("Updates a team's description.")]
+    public static Task<bool> UpdateTeamDescriptionAsync(string organizationUrl, string projectName, string personalAccessToken, string teamName, string newDescription)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.UpdateTeamDescriptionAsync(teamName, newDescription);
+    }
+
+    [McpServerTool, Description("Deletes a team by identifier.")]
+    public static Task<bool> DeleteTeamAsync(string organizationUrl, string projectName, string personalAccessToken, Guid teamGuid)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.DeleteTeamAsync(teamGuid);
+    }
+
+    [McpServerTool, Description("Creates an inherited process from a system process.")]
+    public static Task<bool> CreateInheritedProcessAsync(string organizationUrl, string projectName, string personalAccessToken, string newProcessName, string description, string baseProcessName)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.CreateInheritedProcessAsync(newProcessName, description, baseProcessName);
+    }
+
+    [McpServerTool, Description("Deletes an inherited process by identifier.")]
+    public static Task<bool> DeleteInheritedProcessAsync(string organizationUrl, string projectName, string personalAccessToken, string processId)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.DeleteInheritedProcessAsync(processId);
+    }
+}


### PR DESCRIPTION
## Summary
- reference ProjectSettings core in MCP server
- expose new boards methods for listing boards and retrieving team iteration info
- add ProjectSettings tools for team and process management

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715e06d878832c87d93a26440c2f2f