### PR TITLE
Add backlog & PR linking utilities

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
@@ -30,6 +30,11 @@ namespace Dotnet.AzureDevOps.Core.Boards
         Task<int> GetWorkItemCountAsync(string wiql, CancellationToken cancellationToken = default);
         Task<TeamFieldValues> ListAreasAsync(TeamContext teamContext, CancellationToken cancellationToken = default);
         Task<List<BoardColumn>> ListBoardColumnsAsync(TeamContext teamContext, Guid board, object? userState = null, CancellationToken cancellationToken = default);
+        Task<List<BacklogLevelConfiguration>> ListBacklogsAsync(TeamContext teamContext, object? userState = null, CancellationToken cancellationToken = default);
+        Task<BacklogLevelWorkItems> ListBacklogWorkItemsAsync(TeamContext teamContext, string backlogId, object? userState = null, CancellationToken cancellationToken = default);
+        Task<PredefinedQuery> ListMyWorkItemsAsync(string queryType = "assignedtome", int? top = null, bool? includeCompleted = null, object? userState = null, CancellationToken cancellationToken = default);
+        Task LinkWorkItemToPullRequestAsync(string projectId, string repositoryId, int pullRequestId, int workItemId, CancellationToken cancellationToken = default);
+        Task<IterationWorkItems> GetWorkItemsForIterationAsync(TeamContext teamContext, Guid iterationId, object? userState = null, CancellationToken cancellationToken = default);
         Task<List<TeamSettingsIteration>> ListIterationsAsync(TeamContext teamContext, string? timeFrame = null, object? userState = null, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkItem>> QueryWorkItemsAsync(string wiql, CancellationToken cancellationToken = default);
         Task RemoveLinkAsync(int workItemId, string linkUrl, CancellationToken cancellationToken = default);

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
@@ -349,6 +349,42 @@ namespace Dotnet.AzureDevOps.Core.Boards
         public Task<List<BoardColumn>> ListBoardColumnsAsync(TeamContext teamContext, Guid board, object? userState = null, CancellationToken cancellationToken = default)
             => _workClient.GetBoardColumnsAsync(teamContext, board.ToString(), userState, cancellationToken: cancellationToken);
 
+        public Task<List<BacklogLevelConfiguration>> ListBacklogsAsync(TeamContext teamContext, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetBacklogsAsync(teamContext, userState, cancellationToken);
+
+        public Task<BacklogLevelWorkItems> ListBacklogWorkItemsAsync(TeamContext teamContext, string backlogId, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetBacklogLevelWorkItemsAsync(teamContext, backlogId, userState, cancellationToken);
+
+        public Task<PredefinedQuery> ListMyWorkItemsAsync(string queryType = "assignedtome", int? top = null, bool? includeCompleted = null, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetPredefinedQueryResultsAsync(_projectName, queryType, top, includeCompleted, userState, cancellationToken);
+
+        public async Task LinkWorkItemToPullRequestAsync(string projectId, string repositoryId, int pullRequestId, int workItemId, CancellationToken cancellationToken = default)
+        {
+            string artifactPathValue = $"{projectId}/{repositoryId}/{pullRequestId}";
+            string encodedPath = Uri.EscapeDataString(artifactPathValue);
+            string vstfsUrl = $"vstfs:///Git/PullRequestId/{encodedPath}";
+
+            var patch = new JsonPatchDocument
+            {
+                new JsonPatchOperation
+                {
+                    Operation = Operation.Add,
+                    Path = "/relations/-",
+                    Value = new
+                    {
+                        rel = "ArtifactLink",
+                        url = vstfsUrl,
+                        attributes = new { name = "Pull Request" }
+                    }
+                }
+            };
+
+            _ = await _workItemClient.UpdateWorkItemAsync(patch, workItemId, cancellationToken: cancellationToken);
+        }
+
+        public Task<IterationWorkItems> GetWorkItemsForIterationAsync(TeamContext teamContext, Guid iterationId, object? userState = null, CancellationToken cancellationToken = default)
+            => _workClient.GetIterationWorkItemsAsync(teamContext, iterationId, userState, cancellationToken);
+
         public Task<List<TeamSettingsIteration>> ListIterationsAsync(TeamContext teamContext, string? timeFrame = null, object? userState = null, CancellationToken cancellationToken = default)
             => _workClient.GetTeamIterationsAsync(teamContext, timeFrame, userState, cancellationToken: cancellationToken);
 

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
@@ -167,6 +167,41 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools
             return client.ListBoardColumnsAsync(teamContext, boardId, userState);
         }
 
+        [McpServerTool, Description("Lists backlog configurations for a team.")]
+        public static Task<List<BacklogLevelConfiguration>> ListBacklogsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.ListBacklogsAsync(teamContext, userState);
+        }
+
+        [McpServerTool, Description("Lists work items for a backlog category.")]
+        public static Task<BacklogLevelWorkItems> ListBacklogWorkItemsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, string backlogId, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.ListBacklogWorkItemsAsync(teamContext, backlogId, userState);
+        }
+
+        [McpServerTool, Description("Lists work items relevant to the authenticated user.")]
+        public static Task<PredefinedQuery> ListMyWorkItemsAsync(string organizationUrl, string projectName, string personalAccessToken, string queryType = "assignedtome", int? top = null, bool? includeCompleted = null, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.ListMyWorkItemsAsync(queryType, top, includeCompleted, userState);
+        }
+
+        [McpServerTool, Description("Links a work item to a pull request.")]
+        public static Task LinkWorkItemToPullRequestAsync(string organizationUrl, string projectName, string personalAccessToken, string projectId, string repositoryId, int pullRequestId, int workItemId)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.LinkWorkItemToPullRequestAsync(projectId, repositoryId, pullRequestId, workItemId);
+        }
+
+        [McpServerTool, Description("Lists work items for a specific iteration.")]
+        public static Task<IterationWorkItems> GetWorkItemsForIterationAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, Guid iterationId, object? userState = null)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.GetWorkItemsForIterationAsync(teamContext, iterationId, userState);
+        }
+
         [McpServerTool, Description("Lists boards for a team.")]
         public static Task<List<BoardReference>> ListBoardsAsync(string organizationUrl, string projectName, string personalAccessToken, TeamContext teamContext, object? userState = null)
         {


### PR DESCRIPTION
## Summary
- extend `IWorkItemsClient` with backlog and PR helpers
- implement backlog listing and pull request link logic
- expose new helper methods through MCP server tools

## Testing
- `dotnet build src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/Dotnet.AzureDevOps.Core.Boards.csproj`
- `dotnet build src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj`
- `dotnet test test/unit.tests/Dotnet.AzureDevOps.Boards.Tests/Dotnet.AzureDevOps.Boards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687d50065130832cb74b062e1649edc8