### PR TITLE
Extend artifacts client

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
@@ -4,6 +4,11 @@ using System.Text;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
 using Dotnet.AzureDevOps.Core.Common;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using Microsoft.VisualStudio.Services.Feed.WebApi;
+using Microsoft.VisualStudio.Services.NuGet.WebApi;
+using Microsoft.VisualStudio.Services.Packaging.Shared.WebApi;
 
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;
@@ -15,6 +20,8 @@ public class ArtifactsClient : IArtifactsClient
     private readonly string _projectName;
     private readonly HttpClient _http;
     private readonly string _organizationUrl;
+    private readonly FeedHttpClient _feedHttpClient;
+    private readonly NuGetHttpClient _nuGetHttpClient;
 
     public ArtifactsClient(string organizationUrl, string projectName, string personalAccessToken)
     {
@@ -26,6 +33,11 @@ public class ArtifactsClient : IArtifactsClient
 
         string encodedPersonalAccessToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{personalAccessToken}"));
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", encodedPersonalAccessToken);
+
+        var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
+        var connection = new VssConnection(new Uri(organizationUrl), credentials);
+        _feedHttpClient = connection.GetClient<FeedHttpClient>();
+        _nuGetHttpClient = connection.GetClient<NuGetHttpClient>();
     }
 
     public async Task<Guid> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default)
@@ -108,4 +120,114 @@ public class ArtifactsClient : IArtifactsClient
             cancellationToken: cancellationToken);
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        List<FeedPermission> permissions = await _feedHttpClient.GetFeedPermissionsAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            includeIds: true,
+            excludeInheritedPermissions: false,
+            identityDescriptor: null!,
+            includeDeletedFeeds: false,
+            userState: null,
+            cancellationToken: cancellationToken);
+        return permissions;
+    }
+
+    public async Task SetFeedPermissionsAsync(Guid feedId, IEnumerable<FeedPermission> feedPermissions, CancellationToken cancellationToken = default)
+    {
+        _ = await _feedHttpClient.SetFeedPermissionsAsync(
+            feedPermission: feedPermissions.ToList(),
+            project: _projectName,
+            feedId: feedId.ToString(),
+            userState: null,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default) =>
+        await _feedHttpClient.CreateFeedViewAsync(
+            view: feedView,
+            project: _projectName,
+            feedId: feedId.ToString(),
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default) =>
+        await _feedHttpClient.GetFeedViewsAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default) =>
+        await _feedHttpClient.DeleteFeedViewAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            viewId: viewId,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default) =>
+        await _nuGetHttpClient.SetUpstreamingBehaviorAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            packageName: packageName,
+            body: behavior,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default) =>
+        await _nuGetHttpClient.GetUpstreamingBehaviorAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            packageName: packageName,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default) =>
+        await _nuGetHttpClient.GetPackageVersionAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            packageName: packageName,
+            packageVersion: version,
+            showDeleted: false,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default) =>
+        await _nuGetHttpClient.UpdatePackageVersionAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            packageName: packageName,
+            packageVersion: version,
+            body: details,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default) =>
+        await _nuGetHttpClient.DownloadPackageAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            packageName: packageName,
+            packageVersion: version,
+            sourceProtocolVersion: null,
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default) =>
+        await _feedHttpClient.GetFeedRetentionPoliciesAsync(
+            project: _projectName,
+            feedId: feedId.ToString(),
+            userState: null,
+            cancellationToken: cancellationToken);
+
+    public async Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default) =>
+        await _feedHttpClient.SetFeedRetentionPoliciesAsync(
+            feedRetentionPolicy: policy,
+            project: _projectName,
+            feedId: feedId.ToString(),
+            userState: null,
+            cancellationToken: cancellationToken);
+
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Dotnet.AzureDevOps.Core.Artifacts.csproj
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Dotnet.AzureDevOps.Core.Artifacts.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Packaging.Client" Version="20.259.0-preview" />
     <ProjectReference Include="..\Dotnet.AzureDevOps.Core.Common\Dotnet.AzureDevOps.Core.Common.csproj" />
   </ItemGroup>
 

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
@@ -1,5 +1,9 @@
 ﻿using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
+using Microsoft.VisualStudio.Services.Feed.WebApi;
+using Microsoft.VisualStudio.Services.NuGet.WebApi;
+using Microsoft.VisualStudio.Services.Packaging.Shared.WebApi;
+using System.IO;
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;
 
@@ -18,4 +22,28 @@ public interface IArtifactsClient
     Task<IReadOnlyList<Package>> ListPackagesAsync(Guid feedId, CancellationToken cancellationToken = default);
 
     Task DeletePackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default);
+
+    Task SetFeedPermissionsAsync(Guid feedId, IEnumerable<FeedPermission> feedPermissions, CancellationToken cancellationToken = default);
+
+    Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default);
+
+    Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default);
+
+    Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default);
+
+    Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default);
+
+    Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+
+    Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default);
+
+    Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+
+    Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default);
+
+    Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- add Microsoft Visual Studio services packaging clients
- extend ArtifactsClient with feed permissions, views, upstreams, retention, downloads and versions
- expose new methods in IArtifactsClient
- add required package references

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f8b9934832c9777834bb2993227