### PR TITLE
Add missing repo listing and commit search APIs

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
@@ -59,5 +59,27 @@ namespace Dotnet.AzureDevOps.Core.Repos
         Task<GitAnnotatedTag> GetTagAsync(string repositoryId, string objectId);
 
         Task<GitRefUpdateResult?> DeleteTagAsync(string repositoryId, string tagName);
+
+        Task<IReadOnlyList<GitRepository>> ListRepositoriesAsync();
+
+        Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByProjectAsync(PullRequestSearchOptions pullRequestSearchOptions);
+
+        Task<IReadOnlyList<GitRef>> ListBranchesAsync(string repositoryId);
+
+        Task<IReadOnlyList<GitRef>> ListMyBranchesAsync(string repositoryId);
+
+        Task<IReadOnlyList<GitPullRequestCommentThread>> ListPullRequestThreadsAsync(string repositoryId, int pullRequestId);
+
+        Task<IReadOnlyList<Comment>> ListPullRequestThreadCommentsAsync(string repositoryId, int pullRequestId, int threadId);
+
+        Task<GitRepository?> GetRepositoryByNameAsync(string repositoryName);
+
+        Task<GitRef?> GetBranchAsync(string repositoryId, string branchName);
+
+        Task ResolveCommentThreadAsync(string repositoryId, int pullRequestId, int threadId);
+
+        Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string repositoryId, GitQueryCommitsCriteria searchCriteria, int top = 100);
+
+        Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByCommitsAsync(string repositoryId, IEnumerable<string> commitIds);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/ReposClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/ReposClient.cs
@@ -3,6 +3,9 @@ using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 
 namespace Dotnet.AzureDevOps.Core.Repos
 {
@@ -10,10 +13,14 @@ namespace Dotnet.AzureDevOps.Core.Repos
     {
         private readonly string _projectName;
         private readonly GitHttpClient _gitHttpClient;
+        private readonly string _organizationUrl;
+        private readonly string _personalAccessToken;
 
         public ReposClient(string organizationUrl, string projectName, string personalAccessToken)
         {
             _projectName = projectName;
+            _organizationUrl = organizationUrl;
+            _personalAccessToken = personalAccessToken;
 
             var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
             var connection = new VssConnection(new Uri(organizationUrl), credentials);
@@ -593,6 +600,158 @@ namespace Dotnet.AzureDevOps.Core.Repos
                 searchCriteria: criteria,
                 top: top
             );
+        }
+
+        public async Task<IReadOnlyList<GitRepository>> ListRepositoriesAsync()
+            => await _gitHttpClient.GetRepositoriesAsync(project: _projectName);
+
+        public async Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByProjectAsync(PullRequestSearchOptions pullRequestSearchOptions)
+        {
+            var criteria = new GitPullRequestSearchCriteria
+            {
+                Status = pullRequestSearchOptions.Status,
+                TargetRefName = pullRequestSearchOptions.TargetBranch,
+                SourceRefName = pullRequestSearchOptions.SourceBranch
+            };
+
+            List<GitPullRequest> pullRequests = await _gitHttpClient.GetPullRequestsByProjectAsync(
+                project: _projectName,
+                searchCriteria: criteria,
+                top: 1000
+            );
+
+            return pullRequests;
+        }
+
+        public async Task<IReadOnlyList<GitRef>> ListBranchesAsync(string repositoryId)
+        {
+            List<GitRef> refs = await _gitHttpClient.GetRefsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                filter: "heads/",
+                includeLinks: true,
+                includeStatuses: null,
+                includeMyBranches: false,
+                latestStatusesOnly: null,
+                peelTags: null,
+                filterContains: null
+            );
+
+            return refs;
+        }
+
+        public async Task<IReadOnlyList<GitRef>> ListMyBranchesAsync(string repositoryId)
+        {
+            List<GitRef> refs = await _gitHttpClient.GetRefsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                filter: "heads/",
+                includeLinks: true,
+                includeStatuses: null,
+                includeMyBranches: true,
+                latestStatusesOnly: null,
+                peelTags: null,
+                filterContains: null
+            );
+
+            return refs;
+        }
+
+        public async Task<IReadOnlyList<GitPullRequestCommentThread>> ListPullRequestThreadsAsync(string repositoryId, int pullRequestId)
+            => await _gitHttpClient.GetThreadsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                pullRequestId: pullRequestId,
+                iteration: null,
+                baseIteration: null);
+
+        public async Task<IReadOnlyList<Comment>> ListPullRequestThreadCommentsAsync(string repositoryId, int pullRequestId, int threadId)
+            => await _gitHttpClient.GetCommentsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                pullRequestId: pullRequestId,
+                threadId: threadId);
+
+        public async Task<GitRepository?> GetRepositoryByNameAsync(string repositoryName)
+        {
+            try
+            {
+                return await _gitHttpClient.GetRepositoryAsync(
+                    project: _projectName,
+                    repositoryId: repositoryName
+                );
+            }
+            catch (VssServiceException)
+            {
+                return null;
+            }
+        }
+
+        public async Task<GitRef?> GetBranchAsync(string repositoryId, string branchName)
+        {
+            List<GitRef> refs = await _gitHttpClient.GetRefsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                filter: $"heads/{branchName}",
+                includeLinks: true,
+                includeStatuses: null,
+                includeMyBranches: null,
+                latestStatusesOnly: null,
+                peelTags: null,
+                filterContains: null
+            );
+
+            return refs.FirstOrDefault();
+        }
+
+        public async Task ResolveCommentThreadAsync(string repositoryId, int pullRequestId, int threadId)
+        {
+            var update = new GitPullRequestCommentThread
+            {
+                Id = threadId,
+                Status = CommentThreadStatus.Fixed
+            };
+
+            await _gitHttpClient.UpdateThreadAsync(
+                gitPullRequestCommentThread: update,
+                project: _projectName,
+                repositoryId: repositoryId,
+                pullRequestId: pullRequestId,
+                threadId: threadId
+            );
+        }
+
+        public async Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string repositoryId, GitQueryCommitsCriteria searchCriteria, int top = 100)
+            => await _gitHttpClient.GetCommitsAsync(
+                project: _projectName,
+                repositoryId: repositoryId,
+                searchCriteria: searchCriteria,
+                top: top
+            );
+
+        public async Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByCommitsAsync(string repositoryId, IEnumerable<string> commitIds)
+        {
+            var result = new List<GitPullRequest>();
+            using var httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(_organizationUrl)
+            };
+            string authToken = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
+
+            foreach (string commitId in commitIds)
+            {
+                string requestUrl = $"{_projectName}/_apis/git/repositories/{repositoryId}/commits/{commitId}/pullRequests?api-version=7.0";
+                using HttpResponseMessage message = await httpClient.GetAsync(requestUrl);
+                message.EnsureSuccessStatusCode();
+                var pullRequests = await message.Content.ReadFromJsonAsync<List<GitPullRequest>>();
+                if (pullRequests is not null)
+                {
+                    result.AddRange(pullRequests);
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/ReposClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/ReposClient.cs
@@ -713,7 +713,7 @@ namespace Dotnet.AzureDevOps.Core.Repos
             };
 
             await _gitHttpClient.UpdateThreadAsync(
-                gitPullRequestCommentThread: update,
+                commentThread: update,
                 project: _projectName,
                 repositoryId: repositoryId,
                 pullRequestId: pullRequestId,
@@ -744,7 +744,7 @@ namespace Dotnet.AzureDevOps.Core.Repos
                 string requestUrl = $"{_projectName}/_apis/git/repositories/{repositoryId}/commits/{commitId}/pullRequests?api-version=7.0";
                 using HttpResponseMessage message = await httpClient.GetAsync(requestUrl);
                 message.EnsureSuccessStatusCode();
-                var pullRequests = await message.Content.ReadFromJsonAsync<List<GitPullRequest>>();
+                List<GitPullRequest>? pullRequests = await message.Content.ReadFromJsonAsync<List<GitPullRequest>>();
                 if (pullRequests is not null)
                 {
                     result.AddRange(pullRequests);

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.6.25358.103" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" />
     <PackageReference Include="OpenTelemetry" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ReposTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ReposTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Collections.Generic;
 using Dotnet.AzureDevOps.Core.Repos;
 using Dotnet.AzureDevOps.Core.Repos.Options;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -217,5 +218,82 @@ public class ReposTools
     {
         ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
         return client.GetLatestCommitsAsync(projectName, repositoryName, branchName, top);
+    }
+
+    [McpServerTool, Description("Lists repositories in a project.")]
+    public static Task<IReadOnlyList<GitRepository>> ListRepositoriesAsync(string organizationUrl, string projectName, string personalAccessToken)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListRepositoriesAsync();
+    }
+
+    [McpServerTool, Description("Lists pull requests across the project.")]
+    public static Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByProjectAsync(string organizationUrl, string projectName, string personalAccessToken, PullRequestSearchOptions options)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListPullRequestsByProjectAsync(options);
+    }
+
+    [McpServerTool, Description("Lists branches in a repository.")]
+    public static Task<IReadOnlyList<GitRef>> ListBranchesAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListBranchesAsync(repositoryId);
+    }
+
+    [McpServerTool, Description("Lists my branches in a repository.")]
+    public static Task<IReadOnlyList<GitRef>> ListMyBranchesAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListMyBranchesAsync(repositoryId);
+    }
+
+    [McpServerTool, Description("Lists threads on a pull request.")]
+    public static Task<IReadOnlyList<GitPullRequestCommentThread>> ListPullRequestThreadsAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, int pullRequestId)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListPullRequestThreadsAsync(repositoryId, pullRequestId);
+    }
+
+    [McpServerTool, Description("Lists comments in a pull request thread.")]
+    public static Task<IReadOnlyList<Comment>> ListPullRequestThreadCommentsAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, int pullRequestId, int threadId)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListPullRequestThreadCommentsAsync(repositoryId, pullRequestId, threadId);
+    }
+
+    [McpServerTool, Description("Gets a repository by name.")]
+    public static Task<GitRepository?> GetRepositoryByNameAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryName)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetRepositoryByNameAsync(repositoryName);
+    }
+
+    [McpServerTool, Description("Gets a branch by name.")]
+    public static Task<GitRef?> GetBranchAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, string branchName)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetBranchAsync(repositoryId, branchName);
+    }
+
+    [McpServerTool, Description("Resolves a comment thread.")]
+    public static Task ResolveCommentThreadAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, int pullRequestId, int threadId)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ResolveCommentThreadAsync(repositoryId, pullRequestId, threadId);
+    }
+
+    [McpServerTool, Description("Searches commits in a repository.")]
+    public static Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, GitQueryCommitsCriteria criteria, int top = 100)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.SearchCommitsAsync(repositoryId, criteria, top);
+    }
+
+    [McpServerTool, Description("Lists pull requests containing specific commits.")]
+    public static Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByCommitsAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, IEnumerable<string> commitIds)
+    {
+        ReposClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListPullRequestsByCommitsAsync(repositoryId, commitIds);
     }
 }

--- a/test/end2end.tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests.csproj
+++ b/test/end2end.tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests.csproj
@@ -16,10 +16,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.6.25358.103" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.60.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.60.0" />
-    <PackageReference Include="ModelContextProtocol-SemanticKernel" Version="0.3.0-preview-01" />
-    <PackageReference Include="ModelContextProtocol.Core" Version="0.3.0-preview.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.61.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.61.0" />
+    <PackageReference Include="ModelContextProtocol-SemanticKernel" Version="0.3.0" />
+    <PackageReference Include="ModelContextProtocol.Core" Version="0.3.0-preview.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- extend `IReposClient` with project-wide repo and branch listing, thread enumeration, commit search, and helper lookups
- implement the new methods in `ReposClient` using `GitHttpClient` and raw REST calls where required
- expose the new capabilities through `ReposTools`

## Testing
- `dotnet format --verify-no-changes` *(fails: Restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68879116e9bc832caba7216f8e02d3c5