### PR TITLE
Refactor variable names for clarity

### DIFF
--- a/Set-Local-Test-Dev-Env-Vars.ps1
+++ b/Set-Local-Test-Dev-Env-Vars.ps1
@@ -62,9 +62,9 @@ $vars = @{
     "USE_AZURE_OPENAI"              = "false" # change to "true" to use Azure OpenAI instead of public OpenAI
 }
 
-foreach ($kv in $vars.GetEnumerator()) {
-    [Environment]::SetEnvironmentVariable($kv.Key, $kv.Value, "User")
-    Write-Host "Set $($kv.Key)"
+foreach ($keyValuePair in $vars.GetEnumerator()) {
+    [Environment]::SetEnvironmentVariable($keyValuePair.Key, $keyValuePair.Value, "User")
+    Write-Host "Set $($keyValuePair.Key)"
 }
 
 Write-Host "`nDone! Open a new PowerShell or Command Prompt session to pick up the changes."

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/WorkItemsClient.cs
@@ -277,9 +277,9 @@ namespace Dotnet.AzureDevOps.Core.Boards
         public async Task<IReadOnlyList<int>> CreateWorkItemsBatchAsync(string workItemType, IEnumerable<WorkItemCreateOptions> items, CancellationToken cancellationToken = default)
         {
             var createdIds = new List<int>();
-            foreach(WorkItemCreateOptions opt in items)
+            foreach(WorkItemCreateOptions itemOptions in items)
             {
-                int? id = await CreateWorkItemAsync(workItemType, opt, cancellationToken: cancellationToken);
+                int? id = await CreateWorkItemAsync(workItemType, itemOptions, cancellationToken: cancellationToken);
                 if(id.HasValue)
                     createdIds.Add(id.Value);
             }

--- a/test/integration.tests/Dotnet.AzuredevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzuredevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
@@ -67,7 +67,7 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
             "teamfoundation.sourcecontrol.webapi.githttpclientbase.createpullrequestreviewersasync?view=azure-devops-dotnet")]
         public async Task ListAndReviewers_Workflow_SucceedsAsync()
         {
-            var opts = new PullRequestCreateOptions
+            var pullRequestCreateOptions = new PullRequestCreateOptions
             {
                 RepositoryIdOrName = _repoName,
                 Title = $"IT PR {DateTime.UtcNow:yyyyMMddHHmmss}",
@@ -76,7 +76,7 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
                 TargetBranch = _targetBranch
             };
 
-            int pullRequestId = (await _reposClient.CreatePullRequestAsync(opts)).Value;
+            int pullRequestId = (await _reposClient.CreatePullRequestAsync(pullRequestCreateOptions)).Value;
             _createdPrIds.Add(pullRequestId);
 
             if(!string.IsNullOrWhiteSpace(_userEmail))


### PR DESCRIPTION
## Summary
- rename `opt` variable to `itemOptions`
- rename `opts` variable in integration tests to `pullRequestCreateOptions`
- rename PowerShell foreach variable to `keyValuePair`

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6887a143ac58832cb5aa40d1985c1396