### PR TITLE
Add wiki overview search and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you choose to build on top of this project during the preview phase, be prepa
 The repository contains multiple C# projects that wrap the Microsoft Azure DevOps SDK and REST APIs. Each Azure DevOps tab—Boards, Repos, Pipelines, Artifacts and others—has a project under `/src/` exposing a simplified client interface. These thin wrappers are consumed by `Dotnet.AzureDevOps.Mcp.Server` to surface Model Context Protocol (MCP) tools. While most calls forward to the official SDKs or, when necessary, the REST endpoints, this layer keeps the MCP server decoupled from Azure DevOps so it can evolve independently or swap implementations in the future.
 The solution is organized as a multi‑project workspace targeting **.NET 9**. Each service area of Azure DevOps has its own client library:
 
-* <img width="30px" align="center" alt="Azure Devops Overview" src="https://cdn.vsassets.io/ext/ms.vss-tfs-web/platform-content/Nav-Dashboard.S24hPD.png"/> **Overview** – Wiki creation and page management.
+* <img width="30px" align="center" alt="Azure Devops Overview" src="https://cdn.vsassets.io/ext/ms.vss-tfs-web/platform-content/Nav-Dashboard.S24hPD.png"/> **Overview** – Wiki creation, search, project summary, and dashboard management.
 * <img width="30px" align="center" alt="Azure Devops Boards" src="https://cdn.vsassets.io/ext/ms.vss-work-web/common-content/Content/Nav-Plan.XB8qU6.png"/> **Boards** – CRUD operations for Epics, Features, User Stories, and Tasks.
   Includes listing boards and columns, exporting boards, and retrieving
   iterations.

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
@@ -1,12 +1,20 @@
 using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.Wiki.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.TeamFoundation.Dashboards.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.Overview
 {
     public interface IWikiClient
     {
         Task<int?> CreateOrUpdatePageAsync(Guid wikiId, WikiPageUpdateOptions wikiPageUpdateOptions, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default);
+
+        Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(Guid wikiId, WikiPagesBatchOptions pagesOptions, GitVersionDescriptor? versionDescriptor = null, CancellationToken cancellationToken = default);
+
+        Task<string?> GetPageTextAsync(Guid wikiId, string path, CancellationToken cancellationToken = default);
+
+        Task<string> SearchWikiAsync(WikiSearchOptions searchOptions, CancellationToken cancellationToken = default);
 
         Task<Guid> CreateWikiAsync(WikiCreateOptions wikiCreateOptions, CancellationToken cancellationToken = default);
 
@@ -19,5 +27,11 @@ namespace Dotnet.AzureDevOps.Core.Overview
         Task<WikiV2?> GetWikiAsync(Guid wikiId, CancellationToken cancellationToken = default);
 
         Task<IReadOnlyList<WikiV2>> ListWikisAsync(CancellationToken cancellationToken = default);
+
+        Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default);
+
+        Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default);
+
+        Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/Options/WikiPagesBatchOptions.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/Options/WikiPagesBatchOptions.cs
@@ -1,0 +1,13 @@
+namespace Dotnet.AzureDevOps.Core.Overview.Options;
+
+/// <summary>
+/// Options to list pages from a wiki.
+/// </summary>
+public record WikiPagesBatchOptions
+{
+    public int Top { get; init; } = 20;
+
+    public string? ContinuationToken { get; init; }
+
+    public int? PageViewsForDays { get; init; }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/Options/WikiSearchOptions.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/Options/WikiSearchOptions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Dotnet.AzureDevOps.Core.Overview.Options;
+
+/// <summary>
+/// Options for searching wiki pages.
+/// </summary>
+public record WikiSearchOptions
+{
+    public string SearchText { get; init; } = string.Empty;
+
+    public IReadOnlyList<string>? Project { get; init; }
+
+    public IReadOnlyList<string>? Wiki { get; init; }
+
+    public bool IncludeFacets { get; init; }
+
+    public int Skip { get; init; }
+
+    public int Top { get; init; } = 10;
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/WikiClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/WikiClient.cs
@@ -1,6 +1,15 @@
 using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.Wiki.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.TeamFoundation.Dashboards.WebApi;
+using Dotnet.AzureDevOps.Core.Common;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 
@@ -10,14 +19,22 @@ namespace Dotnet.AzureDevOps.Core.Overview
     {
         private readonly string _projectName;
         private readonly WikiHttpClient _wikiHttpClient;
+        private readonly ProjectHttpClient _projectHttpClient;
+        private readonly DashboardHttpClient _dashboardHttpClient;
+        private readonly string _organizationUrl;
+        private readonly string _personalAccessToken;
 
         public WikiClient(string organizationUrl, string projectName, string personalAccessToken)
         {
             _projectName = projectName;
+            _organizationUrl = organizationUrl;
+            _personalAccessToken = personalAccessToken;
 
             var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
             var connection = new VssConnection(new Uri(organizationUrl), credentials);
             _wikiHttpClient = connection.GetClient<WikiHttpClient>();
+            _projectHttpClient = connection.GetClient<ProjectHttpClient>();
+            _dashboardHttpClient = connection.GetClient<DashboardHttpClient>();
         }
 
         public async Task<Guid> CreateWikiAsync(WikiCreateOptions wikiCreateOptions, CancellationToken cancellationToken = default)
@@ -90,6 +107,117 @@ namespace Dotnet.AzureDevOps.Core.Overview
                     path: path,
                     includeContent: true,
                     cancellationToken: cancellationToken);
+            }
+            catch(VssServiceException)
+            {
+                return null;
+            }
+        }
+
+        public async Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(Guid wikiId, WikiPagesBatchOptions pagesOptions, GitVersionDescriptor? versionDescriptor = null, CancellationToken cancellationToken = default)
+        {
+            var request = new WikiPagesBatchRequest
+            {
+                Top = pagesOptions.Top,
+                ContinuationToken = pagesOptions.ContinuationToken,
+                PageViewsForDays = pagesOptions.PageViewsForDays
+            };
+
+            WikiPageDetail[] pages = await _wikiHttpClient.GetPagesBatchAsync(
+                pagesBatchRequest: request,
+                project: _projectName,
+                wikiIdentifier: wikiId,
+                versionDescriptor: versionDescriptor,
+                cancellationToken: cancellationToken);
+
+            return pages;
+        }
+
+        public async Task<string?> GetPageTextAsync(Guid wikiId, string path, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                Stream stream = await _wikiHttpClient.GetPageTextAsync(
+                    project: _projectName,
+                    wikiIdentifier: wikiId,
+                    path: path,
+                    recursionLevel: VersionControlRecursionType.None,
+                    versionDescriptor: null,
+                    includeContent: true,
+                    cancellationToken: cancellationToken);
+
+                using StreamReader reader = new StreamReader(stream);
+                string content = await reader.ReadToEndAsync();
+                return content;
+            }
+            catch(VssServiceException)
+            {
+                return null;
+            }
+        }
+
+        public async Task<string> SearchWikiAsync(WikiSearchOptions searchOptions, CancellationToken cancellationToken = default)
+        {
+            using HttpClient httpClient = new HttpClient { BaseAddress = new Uri(_organizationUrl) };
+            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", credentials);
+
+            Dictionary<string, string[]> filters = new Dictionary<string, string[]>();
+            if (searchOptions.Project is { Count: > 0 })
+            {
+                filters["Project"] = searchOptions.Project.ToArray();
+            }
+            if (searchOptions.Wiki is { Count: > 0 })
+            {
+                filters["Wiki"] = searchOptions.Wiki.ToArray();
+            }
+
+            var body = new Dictionary<string, object?>
+            {
+                ["searchText"] = searchOptions.SearchText,
+                ["includeFacets"] = searchOptions.IncludeFacets,
+                ["$skip"] = searchOptions.Skip,
+                ["$top"] = searchOptions.Top
+            };
+            if (filters.Count > 0)
+            {
+                body["filters"] = filters;
+            }
+
+            using HttpResponseMessage response = await httpClient.PostAsJsonAsync(
+                requestUri: $"_apis/search/wikisearchresults?api-version={Constants.ApiVersion}",
+                value: body,
+                cancellationToken: cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+
+        public async Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _projectHttpClient.GetProject(_projectName, includeCapabilities: true, includeHistory: false, userState: null, cancellationToken: cancellationToken);
+            }
+            catch(VssServiceException)
+            {
+                return null;
+            }
+        }
+
+        public async Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default)
+        {
+            TeamContext teamContext = new TeamContext(_projectName);
+            DashboardGroup group = await _dashboardHttpClient.GetDashboardsByProjectAsync(teamContext, cancellationToken: cancellationToken);
+            IReadOnlyList<Dashboard> dashboards = group.DashboardEntries?.Select(e => e.Dashboard).Where(d => d != null).ToList() ?? new List<Dashboard>();
+            return dashboards;
+        }
+
+        public async Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                TeamContext teamContext = new TeamContext(_projectName);
+                return await _dashboardHttpClient.GetDashboardAsync(teamContext, dashboardId, cancellationToken: cancellationToken);
             }
             catch(VssServiceException)
             {

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
@@ -3,6 +3,8 @@ using Dotnet.AzureDevOps.Core.Overview;
 using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.Wiki.WebApi;
+using Microsoft.TeamFoundation.Dashboards.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
 using ModelContextProtocol.Server;
 
 namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
@@ -63,5 +65,47 @@ public class OverviewTools
     {
         WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
         return client.DeletePageAsync(wikiId, path, version);
+    }
+
+    [McpServerTool, Description("Lists pages in a wiki.")]
+    public static Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPagesBatchOptions options)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListPagesAsync(wikiId, options);
+    }
+
+    [McpServerTool, Description("Gets wiki page content.")]
+    public static Task<string?> GetPageTextAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetPageTextAsync(wikiId, path);
+    }
+
+    [McpServerTool, Description("Searches wikis for text.")]
+    public static Task<string> SearchWikiAsync(string organizationUrl, string projectName, string personalAccessToken, WikiSearchOptions options)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.SearchWikiAsync(options);
+    }
+
+    [McpServerTool, Description("Retrieves project summary information.")]
+    public static Task<TeamProject?> GetProjectSummaryAsync(string organizationUrl, string projectName, string personalAccessToken)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetProjectSummaryAsync();
+    }
+
+    [McpServerTool, Description("Lists dashboards under the project.")]
+    public static Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(string organizationUrl, string projectName, string personalAccessToken)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListDashboardsAsync();
+    }
+
+    [McpServerTool, Description("Retrieves a dashboard by identifier.")]
+    public static Task<Dashboard?> GetDashboardAsync(string organizationUrl, string projectName, string personalAccessToken, Guid dashboardId)
+    {
+        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetDashboardAsync(dashboardId);
     }
 }


### PR DESCRIPTION
## Summary
- extend overview client to list pages, search wikis, retrieve summary and dashboards
- expose new MCP tools for project summary and dashboard operations
- document these capabilities in the README

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a22e8ae8832c80627118874148ee