### PR TITLE
Remove Packaging Client dependency

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
@@ -4,11 +4,6 @@ using System.Text;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
 using Dotnet.AzureDevOps.Core.Common;
-using Microsoft.VisualStudio.Services.Common;
-using Microsoft.VisualStudio.Services.WebApi;
-using Microsoft.VisualStudio.Services.Feed.WebApi;
-using Microsoft.VisualStudio.Services.NuGet.WebApi;
-using Microsoft.VisualStudio.Services.Packaging.Shared.WebApi;
 
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;
@@ -20,8 +15,6 @@ public class ArtifactsClient : IArtifactsClient
     private readonly string _projectName;
     private readonly HttpClient _http;
     private readonly string _organizationUrl;
-    private readonly FeedHttpClient _feedHttpClient;
-    private readonly NuGetHttpClient _nuGetHttpClient;
 
     public ArtifactsClient(string organizationUrl, string projectName, string personalAccessToken)
     {
@@ -34,10 +27,6 @@ public class ArtifactsClient : IArtifactsClient
         string encodedPersonalAccessToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{personalAccessToken}"));
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", encodedPersonalAccessToken);
 
-        var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
-        var connection = new VssConnection(new Uri(organizationUrl), credentials);
-        _feedHttpClient = connection.GetClient<FeedHttpClient>();
-        _nuGetHttpClient = connection.GetClient<NuGetHttpClient>();
     }
 
     public async Task<Guid> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default)
@@ -123,111 +112,115 @@ public class ArtifactsClient : IArtifactsClient
 
     public async Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default)
     {
-        List<FeedPermission> permissions = await _feedHttpClient.GetFeedPermissionsAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            includeIds: true,
-            excludeInheritedPermissions: false,
-            identityDescriptor: null!,
-            includeDeletedFeeds: false,
-            userState: null,
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/permissions?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
-        return permissions;
+        response.EnsureSuccessStatusCode();
+        FeedPermissionList? list = await response.Content.ReadFromJsonAsync<FeedPermissionList>(cancellationToken);
+        return list?.Value?.ToArray() ?? [];
     }
 
     public async Task SetFeedPermissionsAsync(Guid feedId, IEnumerable<FeedPermission> feedPermissions, CancellationToken cancellationToken = default)
     {
-        _ = await _feedHttpClient.SetFeedPermissionsAsync(
-            feedPermission: feedPermissions.ToList(),
-            project: _projectName,
-            feedId: feedId.ToString(),
-            userState: null,
+        HttpResponseMessage response = await _http.PostAsJsonAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/permissions?api-version={ApiVersion}",
+            value: feedPermissions,
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 
-    public async Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default) =>
-        await _feedHttpClient.CreateFeedViewAsync(
-            view: feedView,
-            project: _projectName,
-            feedId: feedId.ToString(),
-            userState: null,
+    public async Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PostAsJsonAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/views?api-version={ApiVersion}",
+            value: feedView,
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<FeedView>(cancellationToken))!;
+    }
 
-    public async Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default) =>
-        await _feedHttpClient.GetFeedViewsAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            userState: null,
+    public async Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/views?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        FeedViewList? list = await response.Content.ReadFromJsonAsync<FeedViewList>(cancellationToken);
+        return list?.Value?.ToArray() ?? [];
+    }
 
-    public async Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default) =>
-        await _feedHttpClient.DeleteFeedViewAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            viewId: viewId,
-            userState: null,
+    public async Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.DeleteAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/views/{viewId}?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 
-    public async Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default) =>
-        await _nuGetHttpClient.SetUpstreamingBehaviorAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            packageName: packageName,
-            body: behavior,
-            userState: null,
+    public async Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PutAsJsonAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}",
+            value: behavior,
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 
-    public async Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default) =>
-        await _nuGetHttpClient.GetUpstreamingBehaviorAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            packageName: packageName,
-            userState: null,
+    public async Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<UpstreamingBehavior>(cancellationToken))!;
+    }
 
-    public async Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default) =>
-        await _nuGetHttpClient.GetPackageVersionAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            packageName: packageName,
-            packageVersion: version,
-            showDeleted: false,
-            userState: null,
+    public async Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<Package>(cancellationToken))!;
+    }
 
-    public async Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default) =>
-        await _nuGetHttpClient.UpdatePackageVersionAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            packageName: packageName,
-            packageVersion: version,
-            body: details,
-            userState: null,
-            cancellationToken: cancellationToken);
+    public async Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Patch,
+            $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}")
+        {
+            Content = JsonContent.Create(details)
+        };
+        HttpResponseMessage response = await _http.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 
-    public async Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default) =>
-        await _nuGetHttpClient.DownloadPackageAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            packageName: packageName,
-            packageVersion: version,
-            sourceProtocolVersion: null,
-            userState: null,
+    public async Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/nuget/packages/{packageName}/versions/{version}/content?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStreamAsync(cancellationToken);
+    }
 
-    public async Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default) =>
-        await _feedHttpClient.GetFeedRetentionPoliciesAsync(
-            project: _projectName,
-            feedId: feedId.ToString(),
-            userState: null,
+    public async Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/retentionpolicies?api-version={ApiVersion}",
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(cancellationToken))!;
+    }
 
-    public async Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default) =>
-        await _feedHttpClient.SetFeedRetentionPoliciesAsync(
-            feedRetentionPolicy: policy,
-            project: _projectName,
-            feedId: feedId.ToString(),
-            userState: null,
+    public async Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PutAsJsonAsync(
+            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/feeds/{feedId}/retentionpolicies?api-version={ApiVersion}",
+            value: policy,
             cancellationToken: cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(cancellationToken))!;
+    }
 
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Dotnet.AzureDevOps.Core.Artifacts.csproj
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Dotnet.AzureDevOps.Core.Artifacts.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Packaging.Client" Version="20.259.0-preview" />
     <ProjectReference Include="..\Dotnet.AzureDevOps.Core.Common\Dotnet.AzureDevOps.Core.Common.csproj" />
   </ItemGroup>
 

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
@@ -1,8 +1,5 @@
 ﻿using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
-using Microsoft.VisualStudio.Services.Feed.WebApi;
-using Microsoft.VisualStudio.Services.NuGet.WebApi;
-using Microsoft.VisualStudio.Services.Packaging.Shared.WebApi;
 using System.IO;
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedPermission.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedPermission.cs
@@ -1,0 +1,21 @@
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public enum FeedRole
+{
+    Custom,
+    None,
+    Reader,
+    Contributor,
+    Administrator,
+    Collaborator
+}
+
+public record FeedPermission
+{
+    public FeedRole Role { get; init; }
+    public string? IdentityDescriptor { get; init; }
+    public string? IdentityId { get; init; }
+    public string? DisplayName { get; init; }
+    public bool IsInheritedRole { get; init; }
+}
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedPermissionList.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedPermissionList.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public record FeedPermissionList([property: JsonPropertyName("value")] List<FeedPermission> Value);
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedRetentionPolicy.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedRetentionPolicy.cs
@@ -1,0 +1,9 @@
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public record FeedRetentionPolicy
+{
+    public int? AgeLimitInDays { get; init; }
+    public int? CountLimit { get; init; }
+    public int? DaysToKeepRecentlyDownloadedPackages { get; init; }
+}
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedView.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedView.cs
@@ -1,0 +1,26 @@
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public enum FeedViewType
+{
+    None,
+    Release,
+    Implicit
+}
+
+public enum FeedVisibility
+{
+    Private,
+    Collection,
+    Organization,
+    AadTenant
+}
+
+public record FeedView
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Url { get; init; }
+    public FeedViewType Type { get; init; }
+    public FeedVisibility Visibility { get; init; }
+}
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedViewList.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/FeedViewList.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public record FeedViewList([property: JsonPropertyName("value")] List<FeedView> Value);
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/PackageVersionDetails.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/PackageVersionDetails.cs
@@ -1,0 +1,8 @@
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public record PackageVersionDetails
+{
+    public bool Listed { get; init; }
+    public IReadOnlyList<string>? Views { get; init; }
+}
+

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/UpstreamingBehavior.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/Models/UpstreamingBehavior.cs
@@ -1,0 +1,8 @@
+namespace Dotnet.AzureDevOps.Core.Artifacts.Models;
+
+public enum UpstreamingBehavior
+{
+    Allow,
+    Block
+}
+


### PR DESCRIPTION
## Summary
- drop `Microsoft.VisualStudio.Services.Packaging.Client`
- replace SDK-based artifact methods with REST calls
- add internal models for artifact operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887af3a02c4832cbe7979b8cf37b6b6