### PR TITLE
Refactor wiki client summary and dashboard methods

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/DashboardClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/DashboardClient.cs
@@ -1,0 +1,42 @@
+using Microsoft.TeamFoundation.Dashboards.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.Overview
+{
+    public class DashboardClient : IDashboardClient
+    {
+        private readonly string _projectName;
+        private readonly DashboardHttpClient _dashboardHttpClient;
+
+        public DashboardClient(string organizationUrl, string projectName, string personalAccessToken)
+        {
+            _projectName = projectName;
+            var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
+            var connection = new VssConnection(new Uri(organizationUrl), credentials);
+            _dashboardHttpClient = connection.GetClient<DashboardHttpClient>();
+        }
+
+        public async Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default)
+        {
+            TeamContext teamContext = new TeamContext(_projectName);
+            List<Dashboard> group = await _dashboardHttpClient.GetDashboardsByProjectAsync(teamContext, cancellationToken: cancellationToken);
+            IReadOnlyList<Dashboard> dashboards = group?.Where(d => d != null).ToList() ?? [];
+            return dashboards;
+        }
+
+        public async Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                TeamContext teamContext = new TeamContext(_projectName);
+                return await _dashboardHttpClient.GetDashboardAsync(teamContext, dashboardId, cancellationToken: cancellationToken);
+            }
+            catch (VssServiceException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IDashboardClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IDashboardClient.cs
@@ -1,0 +1,10 @@
+using Microsoft.TeamFoundation.Dashboards.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.Overview
+{
+    public interface IDashboardClient
+    {
+        Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default);
+        Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/ISummaryClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/ISummaryClient.cs
@@ -1,0 +1,9 @@
+using Microsoft.TeamFoundation.Core.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.Overview
+{
+    public interface ISummaryClient
+    {
+        Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
@@ -2,7 +2,6 @@ using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.Wiki.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
-using Microsoft.TeamFoundation.Dashboards.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.Overview
 {
@@ -28,10 +27,5 @@ namespace Dotnet.AzureDevOps.Core.Overview
 
         Task<IReadOnlyList<WikiV2>> ListWikisAsync(CancellationToken cancellationToken = default);
 
-        Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default);
-
-        Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default);
-
-        Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/SummaryClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/SummaryClient.cs
@@ -1,0 +1,32 @@
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Dotnet.AzureDevOps.Core.Overview
+{
+    public class SummaryClient : ISummaryClient
+    {
+        private readonly string _projectName;
+        private readonly ProjectHttpClient _projectHttpClient;
+
+        public SummaryClient(string organizationUrl, string projectName, string personalAccessToken)
+        {
+            _projectName = projectName;
+            var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
+            var connection = new VssConnection(new Uri(organizationUrl), credentials);
+            _projectHttpClient = connection.GetClient<ProjectHttpClient>();
+        }
+
+        public async Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _projectHttpClient.GetProject(_projectName, includeCapabilities: true, includeHistory: false, userState: null);
+            }
+            catch (VssServiceException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/WikiClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/WikiClient.cs
@@ -195,38 +195,6 @@ namespace Dotnet.AzureDevOps.Core.Overview
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
-        public async Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                return await _projectHttpClient.GetProject(_projectName, includeCapabilities: true, includeHistory: false, userState: null);
-            }
-            catch(VssServiceException)
-            {
-                return null;
-            }
-        }
-
-        public async Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default)
-        {
-            var teamContext = new TeamContext(_projectName);
-            List<Dashboard> group = await _dashboardHttpClient.GetDashboardsByProjectAsync(teamContext, cancellationToken: cancellationToken);
-            IReadOnlyList<Dashboard> dashboards = group?.Where(d => d != null).ToList() ?? [];
-            return dashboards;
-        }
-
-        public async Task<Dashboard?> GetDashboardAsync(Guid dashboardId, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                TeamContext teamContext = new TeamContext(_projectName);
-                return await _dashboardHttpClient.GetDashboardAsync(teamContext, dashboardId, cancellationToken: cancellationToken);
-            }
-            catch(VssServiceException)
-            {
-                return null;
-            }
-        }
 
         public Task DeletePageAsync(Guid wikiId, string path, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default) =>
             _wikiHttpClient.DeletePageAsync(project: _projectName, wikiIdentifier: wikiId, path: path, versionDescriptor: gitVersionDescriptor, cancellationToken: cancellationToken);

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
@@ -15,97 +15,103 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
 [McpServerToolType]
 public class OverviewTools
 {
-    private static WikiClient CreateClient(string organizationUrl, string projectName, string personalAccessToken)
+    private static WikiClient CreateWikiClient(string organizationUrl, string projectName, string personalAccessToken)
+        => new(organizationUrl, projectName, personalAccessToken);
+
+    private static SummaryClient CreateSummaryClient(string organizationUrl, string projectName, string personalAccessToken)
+        => new(organizationUrl, projectName, personalAccessToken);
+
+    private static DashboardClient CreateDashboardClient(string organizationUrl, string projectName, string personalAccessToken)
         => new(organizationUrl, projectName, personalAccessToken);
 
     [McpServerTool, Description("Creates a new wiki.")]
     public static Task<Guid> CreateWikiAsync(string organizationUrl, string projectName, string personalAccessToken, WikiCreateOptions options)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.CreateWikiAsync(options);
     }
 
     [McpServerTool, Description("Retrieves a wiki by identifier.")]
     public static Task<WikiV2?> GetWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.GetWikiAsync(wikiId);
     }
 
     [McpServerTool, Description("Lists wikis in the project.")]
     public static Task<IReadOnlyList<WikiV2>> ListWikisAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.ListWikisAsync();
     }
 
     [McpServerTool, Description("Deletes a wiki.")]
     public static Task DeleteWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.DeleteWikiAsync(wikiId);
     }
 
     [McpServerTool, Description("Creates or updates a wiki page.")]
     public static Task<int?> CreateOrUpdatePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPageUpdateOptions options, GitVersionDescriptor version)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.CreateOrUpdatePageAsync(wikiId, options, version);
     }
 
     [McpServerTool, Description("Retrieves a wiki page.")]
     public static Task<WikiPageResponse?> GetPageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.GetPageAsync(wikiId, path);
     }
 
     [McpServerTool, Description("Deletes a wiki page.")]
     public static Task DeletePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path, GitVersionDescriptor version)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.DeletePageAsync(wikiId, path, version);
     }
 
     [McpServerTool, Description("Lists pages in a wiki.")]
     public static Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPagesBatchOptions options)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.ListPagesAsync(wikiId, options);
     }
 
     [McpServerTool, Description("Gets wiki page content.")]
     public static Task<string?> GetPageTextAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.GetPageTextAsync(wikiId, path);
     }
 
     [McpServerTool, Description("Searches wikis for text.")]
     public static Task<string> SearchWikiAsync(string organizationUrl, string projectName, string personalAccessToken, WikiSearchOptions options)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
         return client.SearchWikiAsync(options);
     }
 
     [McpServerTool, Description("Retrieves project summary information.")]
     public static Task<TeamProject?> GetProjectSummaryAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        SummaryClient client = CreateSummaryClient(organizationUrl, projectName, personalAccessToken);
         return client.GetProjectSummaryAsync();
     }
 
     [McpServerTool, Description("Lists dashboards under the project.")]
     public static Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        DashboardClient client = CreateDashboardClient(organizationUrl, projectName, personalAccessToken);
         return client.ListDashboardsAsync();
     }
 
     [McpServerTool, Description("Retrieves a dashboard by identifier.")]
     public static Task<Dashboard?> GetDashboardAsync(string organizationUrl, string projectName, string personalAccessToken, Guid dashboardId)
     {
-        WikiClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        DashboardClient client = CreateDashboardClient(organizationUrl, projectName, personalAccessToken);
         return client.GetDashboardAsync(dashboardId);
     }
 }


### PR DESCRIPTION
## Summary
- extract project summary logic into `SummaryClient`
- extract dashboard methods into `DashboardClient`
- create new interfaces `ISummaryClient` and `IDashboardClient`
- update `WikiClient` to remove summary and dashboard helpers
- adjust `OverviewTools` to use new clients

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `for proj in test/unit.tests/*/*.csproj; do dotnet test "$proj" --no-build -v normal; done`

------
https://chatgpt.com/codex/tasks/task_e_6887bc5f912c832ca6ac16603dd37020