### PR TITLE
Add missing methods to IReposClient interface

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
@@ -30,6 +30,8 @@ namespace Dotnet.AzureDevOps.Core.Repos
 
         Task RemoveLabelAsync(string repositoryId, int pullRequestId, string label);
 
+        Task<IReadOnlyList<WebApiTagDefinition>> GetPullRequestLabelsAsync(string repository, int pullRequestId);
+
         Task RemoveReviewersAsync(string repositoryId, int pullRequestId, params string[] reviewerIds);
 
         Task SetPullRequestStatusAsync(string repositoryId, int pullRequestId, PullRequestStatusOptions pullRequestStatusOptions);
@@ -56,6 +58,8 @@ namespace Dotnet.AzureDevOps.Core.Repos
 
         Task DeleteCommentAsync(string repositoryId, int pullRequestId, int threadId, int commentId);
 
+        Task<GitAnnotatedTag> CreateTagAsync(TagCreateOptions tagCreateOptions);
+
         Task<GitAnnotatedTag> GetTagAsync(string repositoryId, string objectId);
 
         Task<GitRefUpdateResult?> DeleteTagAsync(string repositoryId, string tagName);
@@ -77,6 +81,8 @@ namespace Dotnet.AzureDevOps.Core.Repos
         Task<GitRef?> GetBranchAsync(string repositoryId, string branchName);
 
         Task ResolveCommentThreadAsync(string repositoryId, int pullRequestId, int threadId);
+
+        Task<IReadOnlyList<GitCommitRef>> GetLatestCommitsAsync(string projectName, string repositoryName, string branchName, int top = 1);
 
         Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string repositoryId, GitQueryCommitsCriteria searchCriteria, int top = 100);
 


### PR DESCRIPTION
## Summary
- ensure ReposClient interface exposes all implemented methods

## Testing
- `dotnet test --no-build` *(fails: invalid arguments for .NET 9 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888830ce968832ca6ed1bc15b57ebbd