### PR TITLE
Add test type traits

### DIFF
--- a/test/Dotnet.AzureDevOps.Tests.Common/Attributes/TestTypeAttribute.cs
+++ b/test/Dotnet.AzureDevOps.Tests.Common/Attributes/TestTypeAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Dotnet.AzureDevOps.Tests.Common;
+
+[TraitDiscoverer("Dotnet.AzureDevOps.Tests.Common.TestTypeTraitDiscoverer", "Dotnet.AzureDevOps.Tests.Common")]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+public sealed class TestTypeAttribute : Attribute, ITraitAttribute
+{
+    public TestTypeAttribute(TestType type) => Type = type;
+
+    public TestType Type { get; }
+}
+
+public enum TestType
+{
+    Integration,
+    End2End,
+    Unit
+}
+
+public sealed class TestTypeTraitDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        var type = (TestType)traitAttribute.GetConstructorArguments().First();
+        yield return new KeyValuePair<string, string>("TestType", type.ToString().ToLowerInvariant());
+    }
+}

--- a/test/Dotnet.AzureDevOps.Tests.Common/Dotnet.AzureDevOps.Tests.Common.csproj
+++ b/test/Dotnet.AzureDevOps.Tests.Common/Dotnet.AzureDevOps.Tests.Common.csproj
@@ -7,10 +7,11 @@
     <UserSecretsId>406ed649-a4d8-40a4-8185-ceb8b6b67265</UserSecretsId>
   </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    </ItemGroup>
+        <PackageReference Include="xunit" />
+  </ItemGroup>
 </Project>

--- a/test/end2end.tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests/DotnetAzureDevOpsMcpServerAgentTests.cs
+++ b/test/end2end.tests/Dotnet.AzureDevOps.Mcp.Server.Agent.Tests/DotnetAzureDevOpsMcpServerAgentTests.cs
@@ -5,9 +5,11 @@ using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using ModelContextProtocol.Client;
 using Xunit;
+using Dotnet.AzureDevOps.Tests.Common;
 
 namespace Dotnet.AzureDevOps.Mcp.Server.Agent.End2EndTests;
 
+[TestType(TestType.End2End)]
 public sealed class McpAgentIntegrationTests : IClassFixture<TestFixture>
 {
     private readonly TestFixture _fixture;

--- a/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
@@ -6,6 +6,7 @@ using Dotnet.AzureDevOps.Tests.Common;
 
 namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsArtifactsIntegrationTests : IAsyncLifetime
     {
         private readonly ArtifactsClient _artifactsClient;

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 
 namespace Dotnet.AzureDevOps.Boards.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsBoardsIntegrationTests : IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.TeamFoundation.Work.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.ProjectSettings.IntegationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsProjectSettingsIntegrationTests : IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;

--- a/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.TeamFoundation.Wiki.WebApi;
 
 namespace Dotnet.AzureDevOps.Overview.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsOverviewIntegrationTests : IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;

--- a/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.TeamFoundation.Build.WebApi;
 
 namespace Dotnet.AzureDevOps.Pipeline.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsPipelineIntegrationTests : IAsyncLifetime
     {
         private readonly PipelinesClient _pipelines;

--- a/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.TeamFoundation.SourceControl.WebApi;
 
 namespace Dotnet.AzureDevOps.Repos.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsReposIntegrationTests : IAsyncLifetime
     {
         private readonly ReposClient _reposClient;

--- a/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
 
 namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
 {
+    [TestType(TestType.Integration)]
     public class DotnetAzureDevOpsTestPlansIntegrationTests : IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;


### PR DESCRIPTION
## Summary
- add a `TestTypeAttribute` to tag tests with `TestType`
- annotate integration and end-to-end test classes
- reference `xunit` from the common test project

## Testing
- `dotnet test` *(fails: .NET 9.0 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68889e3389bc832cac08175861bd0f12