### PR TITLE
Exclude tests from coverage

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -4,4 +4,13 @@
     <MaxCpuCount>0</MaxCpuCount>
     <DisableParallelization>false</DisableParallelization>
   </RunConfiguration>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <ExcludeByFile>**/test/**</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
 </RunSettings>


### PR DESCRIPTION
## Summary
- add coverage filter in runsettings to exclude test files

## Testing
- `dotnet --version`
- `dotnet test test/Dotnet.AzureDevOps.Tests.Common/Dotnet.AzureDevOps.Tests.Common.csproj --settings .runsettings --logger "trx"` *(fails: NETSDK1045)*


------
https://chatgpt.com/codex/tasks/task_e_6888ca4afa70832ca501c92e864a3a6e