### PR TITLE
Add coverage for ProjectSettingsClient

### DIFF
--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -50,6 +50,39 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests
             Assert.NotNull(areas);
         }
 
+        [Fact]
+        public async Task CreateUpdateAndDeleteTeam_SucceedsAsync()
+        {
+            string teamName = $"it-team-{UtcStamp()}";
+
+            bool created = await _projectSettingsClient.CreateTeamAsync(teamName, "initial");
+            Assert.True(created);
+
+            Guid id = await _projectSettingsClient.GetTeamIdAsync(teamName);
+            Assert.NotEqual(Guid.Empty, id);
+
+            bool updated = await _projectSettingsClient.UpdateTeamDescriptionAsync(teamName, "updated");
+            Assert.True(updated);
+
+            bool deleted = await _projectSettingsClient.DeleteTeamAsync(id);
+            Assert.True(deleted);
+        }
+
+        [Fact]
+        public async Task CreateAndDeleteInheritedProcess_ExecutesAsync()
+        {
+            string processName = $"it-proc-{UtcStamp()}";
+
+            bool created = await _projectSettingsClient.CreateInheritedProcessAsync(processName, "desc", "Agile");
+            Assert.True(created);
+
+            bool deleted = await _projectSettingsClient.DeleteInheritedProcessAsync("00000000-0000-0000-0000-000000000000");
+            Assert.False(deleted);
+        }
+
+        private static string UtcStamp() =>
+            DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+
         public Task InitializeAsync() => Task.CompletedTask;
 
         public Task DisposeAsync() => Task.CompletedTask;


### PR DESCRIPTION
## Summary
- extend ProjectSettings integration tests
- add tests for creating, updating and deleting teams
- add tests for inherited processes

## Testing
- `dotnet test --no-build` *(fails: missing .NET 9 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6888fc3d1718832cb247cd8fdda84a66