### PR TITLE
Exclude server from coverage

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -8,7 +8,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
-          <ExcludeByFile>**/test/**</ExcludeByFile>
+          <ExcludeByFile>**/test/**,**/src/Dotnet.AzureDevOps.Mcp.Server/**</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
## Summary
- exclude Dotnet.AzureDevOps.Mcp.Server project from integration test coverage

## Testing
- `dotnet test` *(fails: Section 'AZURE_DEVOPS_ORG_URL' not found in configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688903e4486c832c9331483c62fd7019