### PR TITLE
Remove Arrange/Act/Assert comments in tests

### DIFF
--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -51,7 +51,6 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         [Fact]
         public async Task CreateEpic_SucceedsAsync()
         {
-            // Arrange
             var options = new WorkItemCreateOptions
             {
                 Title = "Integration Test Epic",
@@ -59,10 +58,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
                 Tags = "IntegrationTest"
             };
 
-            // Act
             int? epicId = await _workItemsClient.CreateEpicAsync(options);
-
-            // Assert
             Assert.True(epicId.HasValue, "Failed to create Epic. ID was null.");
             _createdWorkItemIds.Add(epicId.Value);
         }

--- a/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
@@ -186,8 +186,6 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
         [Fact]
         public async Task Tags_CreateListDelete_Workflow_SucceedsAsync()
         {
-            /* ---------- Arrange ---------- */
-
             IReadOnlyList<GitCommitRef> latestCommits = await _reposClient.GetLatestCommitsAsync(
                 _azureDevOpsConfiguration.ProjectName,
                 _repoName,
@@ -210,15 +208,12 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
                 TaggerEmail = "bot@example.com"
             });
 
-            /* ---------- Assert – list finds annotated tag ---------- */
             GitAnnotatedTag tag = await _reposClient.GetTagAsync(_repoName, gitAnnotatedTag.ObjectId);
 
             Assert.True(tag.Name == annTag);
 
-            /* ---------- Act – delete both tags ---------- */
             GitRefUpdateResult? result = await _reposClient.DeleteTagAsync(_repoName, annTag);
 
-            /* ---------- Assert – annotated tag no longer returned ---------- */
             Assert.NotNull(result);
             Assert.True(result.Success);
         }


### PR DESCRIPTION
## Summary
- clean up integration tests by removing Arrange/Act/Assert comments

## Testing
- `dotnet test --no-build` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_688b2d5a87ec832c8b9733402112bd3b