### PR TITLE
Improve integration test assertions

### DIFF
--- a/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
@@ -81,7 +81,7 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
             _createdFeedIds.Add(feedId);
 
             IReadOnlyList<FeedPermission> permissions = await _artifactsClient.GetFeedPermissionsAsync(feedId);
-            Assert.NotNull(permissions);
+            Assert.NotEmpty(permissions);
         }
 
 

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -544,7 +544,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             List<BoardReference> boardReferences = await _workItemsClient.ListBoardsAsync(teamContext);
-            Assert.NotNull(boardReferences);
+            Assert.NotEmpty(boardReferences);
         }
 
         [Fact]
@@ -564,7 +564,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             List<TeamSettingsIteration> iterations = await _workItemsClient.GetTeamIterationsAsync(teamContext, string.Empty);
-            Assert.NotNull(iterations);
+            Assert.NotEmpty(iterations);
         }
 
         [Fact]
@@ -576,7 +576,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
 
             Guid boardId = boards.First().Id;
             List<BoardColumn> columns = await _workItemsClient.ListBoardColumnsAsync(teamContext, boardId);
-            Assert.NotNull(columns);
+            Assert.NotEmpty(columns);
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             var teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName, "Dotnet.McpIntegrationTest Team");
             List<BacklogLevelConfiguration> backlogs = await _workItemsClient.ListBacklogsAsync(teamContext);
-            Assert.NotNull(backlogs);
+            Assert.NotEmpty(backlogs);
         }
 
         /// <summary>
@@ -651,11 +651,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             List<TeamSettingsIteration> iterations = await _workItemsClient.ListIterationsAsync(teamContext);
-            if(iterations.Count == 0)
-            {
-                Assert.NotNull(iterations);
-                return;
-            }
+            Assert.NotEmpty(iterations);
 
             TeamSettingsIteration iteration = iterations.First();
             IterationWorkItems result = await _workItemsClient.GetWorkItemsForIterationAsync(teamContext, iteration.Id);
@@ -667,7 +663,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             List<TeamSettingsIteration> iterations = await _workItemsClient.ListIterationsAsync(teamContext);
-            Assert.NotNull(iterations);
+            Assert.NotEmpty(iterations);
         }
 
         [Fact]
@@ -688,11 +684,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             List<TeamSettingsIteration> existing = await _workItemsClient.ListIterationsAsync(teamContext);
-            if(existing.Count == 0)
-            {
-                Assert.NotNull(existing);
-                return;
-            }
+            Assert.NotEmpty(existing);
 
             TeamSettingsIteration iteration = existing.First();
             var assignments = new List<IterationAssignmentOptions>
@@ -709,7 +701,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         {
             TeamContext teamContext = new TeamContext(_azureDevOpsConfiguration.ProjectName);
             TeamFieldValues areas = await _workItemsClient.ListAreasAsync(teamContext);
-            Assert.NotNull(areas);
+            Assert.NotEmpty(areas.Values);
         }
 
         /// <summary>

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -36,19 +36,20 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests
             await _projectSettingsClient.CreateTeamAsync(testTeamName, "description1");
             await _projectSettingsClient.UpdateTeamDescriptionAsync(testTeamName, "description2");
             List<BoardReference> boardReferenceList = await _workItemsClient.ListBoardsAsync(teamContext, boardName);
+            Assert.NotEmpty(boardReferenceList);
             List<TeamSettingsIteration> iterations = await _workItemsClient.GetTeamIterationsAsync(teamContext, "");
+            Assert.NotEmpty(iterations);
 
             IReadOnlyList<BoardColumn> cols = await _workItemsClient.ListBoardColumnsAsync(teamContext, boardReferenceList[0].Id, testTeamName);
             await _projectSettingsClient.DeleteTeamAsync(await _projectSettingsClient.GetTeamIdAsync(testTeamName));
 
-            Assert.NotNull(cols);
+            Assert.NotEmpty(cols);
 
             IReadOnlyList<TeamSettingsIteration> iterationList = await _workItemsClient.ListIterationsAsync(teamContext, "current", _azureDevOpsConfiguration.ProjectName);
-            Assert.NotNull(iterations);
-            Assert.NotNull(iterationList);
+            Assert.NotEmpty(iterationList);
 
             TeamFieldValues areas = await _workItemsClient.ListAreasAsync(teamContext);
-            Assert.NotNull(areas);
+            Assert.NotEmpty(areas.Values);
         }
 
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
@@ -204,11 +204,11 @@ namespace Dotnet.AzureDevOps.Pipeline.IntegrationTests
             _queuedBuildIds.Add(buildId);
 
             List<BuildLog> logs = await _pipelines.GetLogsAsync(buildId);
-            Assert.NotNull(logs);
+            Assert.NotEmpty(logs);
 
             List<BuildDefinitionRevision> revisions = await _pipelines.GetDefinitionRevisionsAsync(
                 _definitionId);
-            Assert.NotNull(revisions);
+            Assert.NotEmpty(revisions);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- tighten checks in several integration tests to require data

## Testing
- `dotnet --version`
- `dotnet test` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_688b37f0fdbc832cb2f3b47b817e77fb