### PR TITLE
Use REST for SetFeedPermissionsAsync

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Linq;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
 using Dotnet.AzureDevOps.Core.Common;
@@ -155,10 +154,7 @@ public class ArtifactsClient : IArtifactsClient
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
         };
 
-        // The REST API expects the permissions collection wrapped inside a 'value' object.
-        var payload = new { value = feedPermissions.ToArray() };
-        string json = JsonSerializer.Serialize(payload, options);
-
+        string json = JsonSerializer.Serialize(feedPermissions, options);
         using var request = new HttpRequestMessage(HttpMethod.Patch,
             $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/permissions?api-version={ApiVersion}")
         {

--- a/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
@@ -86,9 +86,8 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
 
 
         /// <summary>
-        /// TODO: giving an unknown 500, try to code with rest api
+        /// Verifies that feed permissions can be updated using the REST API.
         /// </summary>
-        /// <returns></returns>
         [Fact]
         public async Task SetFeedPermissions_SucceedsAsync()
         {
@@ -100,17 +99,10 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
 
             IReadOnlyList<FeedPermission> permissions = await _artifactsClient.GetFeedPermissionsAsync(feedId);
 
-            try
-            {
-                await _artifactsClient.SetFeedPermissionsAsync(feedId, permissions);
+            await _artifactsClient.SetFeedPermissionsAsync(feedId, permissions);
 
-                IReadOnlyList<FeedPermission> updatedPermissions = await _artifactsClient.GetFeedPermissionsAsync(feedId);
-                Assert.Equal(permissions.Count, updatedPermissions.Count);
-            }
-            catch(HttpRequestException ex)
-            {
-                Assert.Contains("500", ex.Message);
-            }
+            IReadOnlyList<FeedPermission> updatedPermissions = await _artifactsClient.GetFeedPermissionsAsync(feedId);
+            Assert.Equal(permissions.Count, updatedPermissions.Count);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- update `ArtifactsClient.SetFeedPermissionsAsync` to call the REST API directly
- simplify integration test for setting feed permissions

## Testing
- `dotnet test` *(fails: NETSDK1045 due to missing .NET 9.0 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688b403da808832ca9803229309ae003