### PR TITLE
Enable custom project creation for custom fields test

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Boards/IWorkItemsClient.cs
@@ -42,7 +42,7 @@ namespace Dotnet.AzureDevOps.Core.Boards
         Task<IReadOnlyList<TeamSettingsIteration>> AssignIterationsAsync(TeamContext teamContext, IEnumerable<IterationAssignmentOptions> iterations, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkItem>> QueryWorkItemsAsync(string wiql, CancellationToken cancellationToken = default);
         Task RemoveLinkAsync(int workItemId, string linkUrl, CancellationToken cancellationToken = default);
-        Task SetCustomFieldAsync(int workItemId, string fieldName, string value, CancellationToken cancellationToken = default);
+        Task<WorkItem> SetCustomFieldAsync(int workItemId, string fieldName, string value, CancellationToken cancellationToken = default);
         Task<int?> UpdateEpicAsync(int epicId, WorkItemCreateOptions updateOptions, CancellationToken cancellationToken = default);
         Task<int?> UpdateFeatureAsync(int featureId, WorkItemCreateOptions updateOptions, CancellationToken cancellationToken = default);
         Task<int?> UpdateTaskAsync(int taskId, WorkItemCreateOptions updateOptions, CancellationToken cancellationToken = default);
@@ -53,7 +53,7 @@ namespace Dotnet.AzureDevOps.Core.Boards
         Task<IReadOnlyList<WitBatchResponse>> UpdateWorkItemsBatchAsync(IEnumerable<(int id, WorkItemCreateOptions options)> updates, bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WitBatchResponse>> LinkWorkItemsBatchAsync(IEnumerable<(int sourceId, int targetId, string relation)> links, bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WitBatchResponse>> CloseWorkItemsBatchAsync(IEnumerable<int> workItemIds, string closedState = "Closed", string? closedReason = "Duplicate", bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
-                Task<IReadOnlyList<WitBatchResponse>> CloseAndLinkDuplicatesBatchAsync(IEnumerable<(int duplicateId, int canonicalId)> pairs, bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<WitBatchResponse>> CloseAndLinkDuplicatesBatchAsync(IEnumerable<(int duplicateId, int canonicalId)> pairs, bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
         Task<List<WorkItem?>> AddChildWorkItemsBatchAsync(int parentId, string childType, IEnumerable<WorkItemCreateOptions> children, bool suppressNotifications = true, bool bypassRules = false, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkItem>> GetWorkItemsBatchByIdsAsync(IEnumerable<int> ids, WorkItemExpand expand = WorkItemExpand.All, IEnumerable<string>? fields = null, CancellationToken cancellationToken = default);
 

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/IProjectSettingsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/IProjectSettingsClient.cs
@@ -8,5 +8,8 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings
         Task<bool> DeleteTeamAsync(Guid teamGuid);
         Task<bool> CreateInheritedProcessAsync(string newProcessName, string description, string baseProcessName);
         Task<bool> DeleteInheritedProcessAsync(string processId);
+        Task<string?> GetProcessIdAsync(string processName);
+        Task<Guid?> CreateProjectAsync(string projectName, string description, string processId);
+        Task<bool> DeleteProjectAsync(Guid projectId);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
@@ -1,9 +1,11 @@
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Dotnet.AzureDevOps.Core.Common;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.Operations;
 using Microsoft.VisualStudio.Services.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.ProjectSettings

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.ProjectSettings/ProjectSettingsClient.cs
@@ -13,6 +13,8 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings
         private readonly string _organizationUrl;
         private readonly string _projectName;
         private readonly TeamHttpClient _teamClient;
+        private readonly ProjectHttpClient _projectClient;
+        private readonly OperationsHttpClient _operationsClient;
         private readonly string _personalAccessToken;
 
         public ProjectSettingsClient(string organizationUrl, string projectName, string personalAccessToken)
@@ -24,6 +26,8 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings
             var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
             var connection = new VssConnection(new Uri(_organizationUrl), credentials);
             _teamClient = connection.GetClient<TeamHttpClient>();
+            _projectClient = connection.GetClient<ProjectHttpClient>();
+            _operationsClient = connection.GetClient<OperationsHttpClient>();
         }
 
         public async Task<bool> CreateTeamAsync(string teamName, string teamDescription)
@@ -147,6 +151,73 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings
             HttpResponseMessage response = await client.DeleteAsync(url);
 
             return response.IsSuccessStatusCode;
+        }
+
+        public async Task<string?> GetProcessIdAsync(string processName)
+        {
+            string url = $"{_organizationUrl}/_apis/work/processes?api-version={GlobalConstants.ApiVersion}";
+
+            using var client = new HttpClient();
+            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_personalAccessToken}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+            JsonElement response = await client.GetFromJsonAsync<JsonElement>(url);
+
+            foreach(JsonElement element in response.GetProperty("value").EnumerateArray())
+            {
+                string? name = element.GetProperty("name").GetString();
+                if(string.Equals(name, processName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return element.GetProperty("typeId").GetString();
+                }
+            }
+
+            return null;
+        }
+
+        public async Task<Guid?> CreateProjectAsync(string projectName, string description, string processId)
+        {
+            var teamProject = new TeamProject
+            {
+                Name = projectName,
+                Description = description,
+                Capabilities = new Dictionary<string, Dictionary<string, string>>
+                {
+                    ["versioncontrol"] = new Dictionary<string, string> { ["sourceControlType"] = "Git" },
+                    ["processTemplate"] = new Dictionary<string, string> { ["templateTypeId"] = processId }
+                }
+            };
+
+            OperationReference operationReference = await _projectClient.QueueCreateProject(teamProject, userState: null);
+
+            Operation operation = await WaitForOperationAsync(operationReference.Id);
+            if(operation.Status != OperationStatus.Succeeded)
+            {
+                return null;
+            }
+
+            TeamProject? createdProject = await _projectClient.GetProject(projectName);
+            return createdProject?.Id;
+        }
+
+        public async Task<bool> DeleteProjectAsync(Guid projectId)
+        {
+            OperationReference operationReference = await _projectClient.QueueDeleteProject(projectId, userState: null);
+            Operation operation = await WaitForOperationAsync(operationReference.Id);
+            return operation.Status == OperationStatus.Succeeded;
+        }
+
+        private async Task<Operation> WaitForOperationAsync(Guid operationId)
+        {
+            Operation operation;
+            do
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                operation = await _operationsClient.GetOperation(operationId, userState: null);
+            }
+            while(operation.Status == OperationStatus.InProgress || operation.Status == OperationStatus.Queued);
+
+            return operation;
         }
     }
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
@@ -57,4 +57,25 @@ public static class ProjectSettingsTools
         ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
         return client.DeleteInheritedProcessAsync(processId);
     }
+
+    [McpServerTool, Description("Gets a process identifier by name.")]
+    public static Task<string?> GetProcessIdAsync(string organizationUrl, string projectName, string personalAccessToken, string processName)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetProcessIdAsync(processName);
+    }
+
+    [McpServerTool, Description("Creates a new project using a specified process.")]
+    public static Task<Guid?> CreateProjectAsync(string organizationUrl, string projectName, string personalAccessToken, string newProjectName, string description, string processId)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.CreateProjectAsync(newProjectName, description, processId);
+    }
+
+    [McpServerTool, Description("Deletes a project by identifier.")]
+    public static Task<bool> DeleteProjectAsync(string organizationUrl, string projectName, string personalAccessToken, Guid projectId)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.DeleteProjectAsync(projectId);
+    }
 }

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/Dotnet.AzureDevOps.Boards.IntegrationTests.csproj
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/Dotnet.AzureDevOps.Boards.IntegrationTests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Boards\Dotnet.AzureDevOps.Core.Boards.csproj" />
+    <ProjectReference Include="..\..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.ProjectSettings\Dotnet.AzureDevOps.Core.ProjectSettings.csproj" />
     <ProjectReference Include="..\..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Repos\Dotnet.AzureDevOps.Core.Repos.csproj" />
     <ProjectReference Include="..\..\Dotnet.AzureDevOps.Tests.Common\Dotnet.AzureDevOps.Tests.Common.csproj" />
   </ItemGroup>

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -2,9 +2,9 @@
 using Dotnet.AzureDevOps.Core.Boards;
 using Dotnet.AzureDevOps.Core.Boards.Options;
 using Dotnet.AzureDevOps.Core.Common;
+using Dotnet.AzureDevOps.Core.ProjectSettings;
 using Dotnet.AzureDevOps.Core.Repos;
 using Dotnet.AzureDevOps.Core.Repos.Options;
-using Dotnet.AzureDevOps.Core.ProjectSettings;
 using Dotnet.AzureDevOps.Tests.Common;
 using Dotnet.AzureDevOps.Tests.Common.Attributes;
 using Microsoft.TeamFoundation.Core.WebApi.Types;
@@ -720,6 +720,8 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         public async Task CustomFieldWorkflow_SucceedsAsync()
         {
             WorkItemsClient client = _workItemsClient;
+            string fieldName = "CustomIntegrationTestField";
+            string referenceName = "TestField.ForIntegration";
 
             if(await _workItemsClient.IsSystemProcessAsync())
             {
@@ -745,8 +747,10 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
             Assert.True(workItemId.HasValue);
             _createdWorkItemIds.Add(workItemId!.Value);
 
-            await client.SetCustomFieldAsync(workItemId.Value, "Custom.TestField", "Value1");
-            object? fieldValue = await client.GetCustomFieldAsync(workItemId.Value, "Custom.TestField");
+            await client.CreateCustomFieldIfDoesntExistAsync(fieldName, referenceName, Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.FieldType.String, "test field");
+
+            WorkItem workItem = await client.SetCustomFieldAsync(workItemId.Value, fieldName, "Value1");
+            object? fieldValue = await client.GetCustomFieldAsync(workItemId.Value, referenceName);
             Assert.NotNull(fieldValue);
         }
 

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -713,7 +713,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         }
 
         /// <summary>
-        /// TODO: create a non system project before
+        /// Requires a custom process to be created first, as it uses a custom field.
         /// </summary>
         /// <returns></returns>
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -4,6 +4,7 @@ using Dotnet.AzureDevOps.Core.Boards.Options;
 using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.Repos;
 using Dotnet.AzureDevOps.Core.Repos.Options;
+using Dotnet.AzureDevOps.Core.ProjectSettings;
 using Dotnet.AzureDevOps.Tests.Common;
 using Dotnet.AzureDevOps.Tests.Common.Attributes;
 using Microsoft.TeamFoundation.Core.WebApi.Types;
@@ -20,8 +21,10 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly WorkItemsClient _workItemsClient;
         private readonly ReposClient _reposClient;
+        private readonly ProjectSettingsClient _projectSettingsClient;
         private readonly List<int> _createdWorkItemIds = [];
         private readonly List<int> _createdPullRequestIds = [];
+        private readonly List<Guid> _createdProjectIds = [];
         private readonly string _repositoryName;
         private readonly string _sourceBranch;
         private readonly string _targetBranch;
@@ -36,6 +39,11 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
                 _azureDevOpsConfiguration.PersonalAccessToken);
 
             _reposClient = new ReposClient(
+                _azureDevOpsConfiguration.OrganisationUrl,
+                _azureDevOpsConfiguration.ProjectName,
+                _azureDevOpsConfiguration.PersonalAccessToken);
+
+            _projectSettingsClient = new ProjectSettingsClient(
                 _azureDevOpsConfiguration.OrganisationUrl,
                 _azureDevOpsConfiguration.ProjectName,
                 _azureDevOpsConfiguration.PersonalAccessToken);
@@ -711,20 +719,35 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         [Fact]
         public async Task CustomFieldWorkflow_SucceedsAsync()
         {
-            if(!await _workItemsClient.IsSystemProcessAsync())
-            {
-                int? workItemId = await _workItemsClient.CreateTaskAsync(new WorkItemCreateOptions { Title = "Custom Field" });
-                Assert.True(workItemId.HasValue);
-                _createdWorkItemIds.Add(workItemId!.Value);
+            WorkItemsClient client = _workItemsClient;
 
-                await _workItemsClient.SetCustomFieldAsync(workItemId.Value, "Custom.TestField", "Value1");
-                object? fieldValue = await _workItemsClient.GetCustomFieldAsync(workItemId.Value, "Custom.TestField");
-                Assert.NotNull(fieldValue);
-            }
-            else
+            if(await _workItemsClient.IsSystemProcessAsync())
             {
-                Assert.True(true, "Skipping custom field test for system process.");
+                string processName = $"it-proc-{UtcStamp()}";
+                bool processCreated = await _projectSettingsClient.CreateInheritedProcessAsync(processName, "Custom", "Agile");
+                Assert.True(processCreated);
+
+                string? processId = await _projectSettingsClient.GetProcessIdAsync(processName);
+                Assert.False(string.IsNullOrEmpty(processId));
+
+                string projectName = $"it-proj-{UtcStamp()}";
+                Guid? projectId = await _projectSettingsClient.CreateProjectAsync(projectName, "Custom field project", processId!);
+                Assert.True(projectId.HasValue);
+                _createdProjectIds.Add(projectId!.Value);
+
+                client = new WorkItemsClient(
+                    _azureDevOpsConfiguration.OrganisationUrl,
+                    projectName,
+                    _azureDevOpsConfiguration.PersonalAccessToken);
             }
+
+            int? workItemId = await client.CreateTaskAsync(new WorkItemCreateOptions { Title = "Custom Field" });
+            Assert.True(workItemId.HasValue);
+            _createdWorkItemIds.Add(workItemId!.Value);
+
+            await client.SetCustomFieldAsync(workItemId.Value, "Custom.TestField", "Value1");
+            object? fieldValue = await client.GetCustomFieldAsync(workItemId.Value, "Custom.TestField");
+            Assert.NotNull(fieldValue);
         }
 
         [Fact]
@@ -1147,6 +1170,14 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
             {
                 await _reposClient.AbandonPullRequestAsync(_repositoryName, prId);
             }
+
+            foreach(Guid projectId in _createdProjectIds.AsEnumerable().Reverse())
+            {
+                await _projectSettingsClient.DeleteProjectAsync(projectId);
+            }
         }
+
+        private static string UtcStamp() =>
+            DateTime.UtcNow.ToString("O").Replace(':', '-');
     }
 }


### PR DESCRIPTION
## Summary
- expand project settings client with operations for creating/deleting projects and retrieving process ids
- expose new project management tools in MCP server
- extend boards integration tests to create a custom process and project when needed

## Testing
- ❌ `dotnet restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b5555ee54832c9238538d101c338a