### PR TITLE
Fix LinkWorkItemsBatch using REST

### DIFF
--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -1186,15 +1186,8 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
             };
 
 
-            try
-            {
-                IReadOnlyList<WitBatchResponse> resp = await _workItemsClient.LinkWorkItemsByNameBatchAsync(links);
-                Assert.Single(resp);
-            }
-            catch(VssServiceException ex)
-            {
-                Assert.Contains("Not Found", ex.Message);
-            }
+            IReadOnlyList<WitBatchResponse> resp = await _workItemsClient.LinkWorkItemsByNameBatchAsync(links);
+            Assert.Single(resp);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- implement WorkItemsClient.ExecuteBatchAsync via REST API using current 7.1 version
- remove obsolete NotFound check in LinkWorkItemsByNameBatch_SucceedsAsync

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8d66f388832cae51609554359b06