### PR TITLE
refactor: share integration test clients via fixture

### DIFF
--- a/test/Dotnet.AzureDevOps.Tests.Common/Dotnet.AzureDevOps.Tests.Common.csproj
+++ b/test/Dotnet.AzureDevOps.Tests.Common/Dotnet.AzureDevOps.Tests.Common.csproj
@@ -15,4 +15,15 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
         <PackageReference Include="xunit" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Artifacts\Dotnet.AzureDevOps.Core.Artifacts.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Boards\Dotnet.AzureDevOps.Core.Boards.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.ProjectSettings\Dotnet.AzureDevOps.Core.ProjectSettings.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Repos\Dotnet.AzureDevOps.Core.Repos.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Pipelines\Dotnet.AzureDevOps.Core.Pipelines.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Overview\Dotnet.AzureDevOps.Core.Overview.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.Search\Dotnet.AzureDevOps.Core.Search.csproj" />
+    <ProjectReference Include="..\..\src\Dotnet.AzureDevOps.Core\Dotnet.AzureDevOps.Core.TestPlans\Dotnet.AzureDevOps.Core.TestPlans.csproj" />
+  </ItemGroup>
 </Project>

--- a/test/Dotnet.AzureDevOps.Tests.Common/IntegrationTestFixture.cs
+++ b/test/Dotnet.AzureDevOps.Tests.Common/IntegrationTestFixture.cs
@@ -1,0 +1,78 @@
+using Dotnet.AzureDevOps.Core.Artifacts;
+using Dotnet.AzureDevOps.Core.Boards;
+using Dotnet.AzureDevOps.Core.Overview;
+using Dotnet.AzureDevOps.Core.Pipelines;
+using Dotnet.AzureDevOps.Core.ProjectSettings;
+using Dotnet.AzureDevOps.Core.Repos;
+using Dotnet.AzureDevOps.Core.Search;
+using Dotnet.AzureDevOps.Core.TestPlans;
+using Xunit;
+
+namespace Dotnet.AzureDevOps.Tests.Common;
+
+public class IntegrationTestFixture : IAsyncLifetime
+{
+    public AzureDevOpsConfiguration Configuration { get; private set; } = null!;
+    public WorkItemsClient WorkItemsClient { get; private set; } = null!;
+    public ReposClient ReposClient { get; private set; } = null!;
+    public ProjectSettingsClient ProjectSettingsClient { get; private set; } = null!;
+    public PipelinesClient PipelinesClient { get; private set; } = null!;
+    public ArtifactsClient ArtifactsClient { get; private set; } = null!;
+    public WikiClient WikiClient { get; private set; } = null!;
+    public SearchClient SearchClient { get; private set; } = null!;
+    public IdentityClient IdentityClient { get; private set; } = null!;
+    public TestPlansClient TestPlansClient { get; private set; } = null!;
+
+    public Task InitializeAsync()
+    {
+        Configuration = AzureDevOpsConfiguration.FromEnvironment();
+
+        WorkItemsClient = new WorkItemsClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        ReposClient = new ReposClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        ProjectSettingsClient = new ProjectSettingsClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        PipelinesClient = new PipelinesClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        ArtifactsClient = new ArtifactsClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        WikiClient = new WikiClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        SearchClient = new SearchClient(
+            Configuration.Organisation,
+            Configuration.PersonalAccessToken);
+
+        IdentityClient = new IdentityClient(
+            Configuration.OrganisationUrl,
+            Configuration.PersonalAccessToken);
+
+        TestPlansClient = new TestPlansClient(
+            Configuration.OrganisationUrl,
+            Configuration.ProjectName,
+            Configuration.PersonalAccessToken);
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+

--- a/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
@@ -8,20 +8,16 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.Artifacts)]
-    public class DotnetAzureDevOpsArtifactsIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsArtifactsIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly ArtifactsClient _artifactsClient;
         private readonly List<Guid> _createdFeedIds = [];
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
 
-        public DotnetAzureDevOpsArtifactsIntegrationTests()
+        public DotnetAzureDevOpsArtifactsIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
-
-            _artifactsClient = new ArtifactsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _azureDevOpsConfiguration = fixture.Configuration;
+            _artifactsClient = fixture.ArtifactsClient;
         }
 
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Boards.IntegrationTests/DotnetAzureDevOpsBoardsIntegrationTests.cs
@@ -17,7 +17,7 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.Boards)]
-    public class DotnetAzureDevOpsBoardsIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsBoardsIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly WorkItemsClient _workItemsClient;
@@ -30,24 +30,12 @@ namespace Dotnet.AzureDevOps.Boards.IntegrationTests
         private readonly string _sourceBranch;
         private readonly string _targetBranch;
 
-        public DotnetAzureDevOpsBoardsIntegrationTests()
+        public DotnetAzureDevOpsBoardsIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
-
-            _workItemsClient = new WorkItemsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-
-            _reposClient = new ReposClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-
-            _projectSettingsClient = new ProjectSettingsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _azureDevOpsConfiguration = fixture.Configuration;
+            _workItemsClient = fixture.WorkItemsClient;
+            _reposClient = fixture.ReposClient;
+            _projectSettingsClient = fixture.ProjectSettingsClient;
 
             _repositoryName = _azureDevOpsConfiguration.RepoName;
             _sourceBranch = _azureDevOpsConfiguration.SrcBranch;

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -9,23 +9,17 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.ProjectSettings)]
-    public class DotnetAzureDevOpsProjectSettingsIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsProjectSettingsIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly ProjectSettingsClient _projectSettingsClient;
         private readonly WorkItemsClient _workItemsClient;
 
-        public DotnetAzureDevOpsProjectSettingsIntegrationTests()
+        public DotnetAzureDevOpsProjectSettingsIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
-            _projectSettingsClient = new ProjectSettingsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-            _workItemsClient = new WorkItemsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _azureDevOpsConfiguration = fixture.Configuration;
+            _projectSettingsClient = fixture.ProjectSettingsClient;
+            _workItemsClient = fixture.WorkItemsClient;
         }
 
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
@@ -14,26 +14,18 @@ namespace Dotnet.AzureDevOps.Overview.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.Overview)]
-    public class DotnetAzureDevOpsOverviewIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsOverviewIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly WikiClient _wikiClient;
         private readonly List<Guid> _createdWikis = [];
         private readonly ProjectSettingsClient _projectSettingsClient;
 
-        public DotnetAzureDevOpsOverviewIntegrationTests()
+        public DotnetAzureDevOpsOverviewIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
-
-            _wikiClient = new WikiClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-
-            _projectSettingsClient = new ProjectSettingsClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _azureDevOpsConfiguration = fixture.Configuration;
+            _wikiClient = fixture.WikiClient;
+            _projectSettingsClient = fixture.ProjectSettingsClient;
         }
 
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Pipeline.IntegrationTests/DotnetAzureDevOpsPipelineIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Dotnet.AzureDevOps.Pipeline.IntegrationTests
     [TestType(TestType.Integration)]
     [Component(Component.Pipelines)]
 
-    public class DotnetAzureDevOpsPipelineIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsPipelineIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly PipelinesClient _pipelines;
         private readonly List<int> _queuedBuildIds = [];
@@ -22,18 +22,15 @@ namespace Dotnet.AzureDevOps.Pipeline.IntegrationTests
         private readonly string _branch;
         private readonly string? _commitSha;
 
-        public DotnetAzureDevOpsPipelineIntegrationTests()
+        public DotnetAzureDevOpsPipelineIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
+            _azureDevOpsConfiguration = fixture.Configuration;
 
             _definitionId = _azureDevOpsConfiguration.PipelineDefinitionId;
             _branch = _azureDevOpsConfiguration.BuildBranch;
             _commitSha = _azureDevOpsConfiguration.CommitSha;
 
-            _pipelines = new PipelinesClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _pipelines = fixture.PipelinesClient;
         }
 
         [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Repos.IntegrationTests/DotnetAzureDevOpsReposIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.Repos)]
-    public class DotnetAzureDevOpsReposIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsReposIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly ReposClient _reposClient;
         private readonly IdentityClient _identityClient;
@@ -25,21 +25,16 @@ namespace Dotnet.AzureDevOps.Repos.IntegrationTests
         // Track created PRs so we can abandon if something fails
         private readonly List<int> _createdPrIds = [];
 
-        public DotnetAzureDevOpsReposIntegrationTests()
+        public DotnetAzureDevOpsReposIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
+            _azureDevOpsConfiguration = fixture.Configuration;
             _repoName = _azureDevOpsConfiguration.RepoName ?? string.Empty;
             _srcBranch = _azureDevOpsConfiguration.SrcBranch;
             _targetBranch = _azureDevOpsConfiguration.TargetBranch;
             _userEmail = _azureDevOpsConfiguration.BotUserEmail;
 
-            _reposClient = new ReposClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-            _identityClient = new IdentityClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _reposClient = fixture.ReposClient;
+            _identityClient = fixture.IdentityClient;
         }
 
         public async Task CreateReadCompletePullRequest_SucceedsAsync()

--- a/test/integration.tests/Dotnet.AzureDevOps.Search.IntegrationTests/DotnetAzureDevOpsSearchIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Search.IntegrationTests/DotnetAzureDevOpsSearchIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace Dotnet.AzureDevOps.Search.IntegrationTests;
 
 [TestType(TestType.Integration)]
 [Component(Component.Search)]
-public class DotnetAzureDevOpsSearchIntegrationTests : IAsyncLifetime
+public class DotnetAzureDevOpsSearchIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
 {
     private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
     private readonly WikiClient _wikiClient;
@@ -23,23 +23,12 @@ public class DotnetAzureDevOpsSearchIntegrationTests : IAsyncLifetime
     private readonly List<Guid> _createdWikis = [];
     private readonly List<int> _createdWorkItemIds = [];
 
-    public DotnetAzureDevOpsSearchIntegrationTests()
+    public DotnetAzureDevOpsSearchIntegrationTests(IntegrationTestFixture fixture)
     {
-        _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
-
-        _wikiClient = new WikiClient(
-            _azureDevOpsConfiguration.OrganisationUrl,
-            _azureDevOpsConfiguration.ProjectName,
-            _azureDevOpsConfiguration.PersonalAccessToken);
-
-        _workItemsClient = new WorkItemsClient(
-            _azureDevOpsConfiguration.OrganisationUrl,
-            _azureDevOpsConfiguration.ProjectName,
-            _azureDevOpsConfiguration.PersonalAccessToken);
-
-        _searchClient = new SearchClient(
-            _azureDevOpsConfiguration.Organisation,
-            _azureDevOpsConfiguration.PersonalAccessToken);
+        _azureDevOpsConfiguration = fixture.Configuration;
+        _wikiClient = fixture.WikiClient;
+        _workItemsClient = fixture.WorkItemsClient;
+        _searchClient = fixture.SearchClient;
     }
 
     [Fact]

--- a/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
 {
     [TestType(TestType.Integration)]
     [Component(Component.TestPlans)]
-    public class DotnetAzureDevOpsTestPlansIntegrationTests : IAsyncLifetime
+    public class DotnetAzureDevOpsTestPlansIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly TestPlansClient _testPlansClient;
@@ -20,19 +20,12 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
         private readonly List<int> _createdPlanIds = [];
         private readonly List<int> _queuedBuildIds = [];
 
-        public DotnetAzureDevOpsTestPlansIntegrationTests()
+        public DotnetAzureDevOpsTestPlansIntegrationTests(IntegrationTestFixture fixture)
         {
-            _azureDevOpsConfiguration = AzureDevOpsConfiguration.FromEnvironment();
+            _azureDevOpsConfiguration = fixture.Configuration;
 
-            _testPlansClient = new TestPlansClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
-
-            _pipelinesClient = new PipelinesClient(
-                _azureDevOpsConfiguration.OrganisationUrl,
-                _azureDevOpsConfiguration.ProjectName,
-                _azureDevOpsConfiguration.PersonalAccessToken);
+            _testPlansClient = fixture.TestPlansClient;
+            _pipelinesClient = fixture.PipelinesClient;
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- add `IntegrationTestFixture` to load Azure DevOps configuration and create shared clients
- refactor integration tests to use the fixture via `IClassFixture`
- wire common test project to required core libraries

## Testing
- `~/.dotnet/dotnet test` *(fails: Server exposes at least one MCP tool [FAIL], plus many others)*

------
https://chatgpt.com/codex/tasks/task_e_688fe247a5e0832cb73c1fe04cea096e