### PR TITLE
Replace fixed delays with polling helper

### DIFF
--- a/test/Dotnet.AzureDevOps.Tests.Common/WaitHelper.cs
+++ b/test/Dotnet.AzureDevOps.Tests.Common/WaitHelper.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Dotnet.AzureDevOps.Tests.Common;
+
+public static class WaitHelper
+{
+    public static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout, TimeSpan pollInterval)
+    {
+        DateTime start = DateTime.UtcNow;
+        while(DateTime.UtcNow - start < timeout)
+        {
+            if(await condition())
+                return;
+            await Task.Delay(pollInterval);
+        }
+        throw new TimeoutException("The condition was not met within the specified timeout.");
+    }
+}

--- a/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests/DotnetAzureDevOpsProjectSettingsIntegrationTests.cs
@@ -73,8 +73,9 @@ namespace Dotnet.AzureDevOps.Core.ProjectSettings.IntegrationTests
 
             bool created = await _projectSettingsClient.CreateInheritedProcessAsync(processName, "Inherited Process integration test", "Agile");
             Assert.True(created, "Process was not created");
-
-            await Task.Delay(2000);
+            await WaitHelper.WaitUntilAsync(async () =>
+                await _projectSettingsClient.GetProcessIdAsync(processName) is not null,
+                TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
 
             bool deleted = await _projectSettingsClient.DeleteInheritedProcessAsync("00000000-0000-0000-0000-000000000000");
             Assert.False(deleted, "Process was not deleted");

--- a/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Overview.IntegrationTests/DotnetAzureDevOpsOverviewIntegrationTests.cs
@@ -60,9 +60,12 @@ namespace Dotnet.AzureDevOps.Overview.IntegrationTests
 
             await _wikiClient.DeleteWikiAsync(id);
             _createdWikis.Remove(id);
-
-            await Task.Delay(3000); // wait for deletion to propagate
-            WikiV2? afterDelete = await _wikiClient.GetWikiAsync(id);
+            WikiV2? afterDelete = null;
+            await WaitHelper.WaitUntilAsync(async () =>
+            {
+                afterDelete = await _wikiClient.GetWikiAsync(id);
+                return afterDelete is null;
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             Assert.Null(afterDelete);
         }
 

--- a/test/integration.tests/Dotnet.AzureDevOps.Search.IntegrationTests/DotnetAzureDevOpsSearchIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Search.IntegrationTests/DotnetAzureDevOpsSearchIntegrationTests.cs
@@ -47,8 +47,18 @@ public class DotnetAzureDevOpsSearchIntegrationTests : IClassFixture<Integration
                 Version = _azureDevOpsConfiguration.MainBranchName
             }
         };
-
-        await Task.Delay(10000);
+        await WaitHelper.WaitUntilAsync(async () =>
+        {
+            try
+            {
+                await _wikiClient.ListWikisAsync();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
         Guid wikiId = await _wikiClient.CreateWikiAsync(wikiCreateOptions);
         _createdWikis.Add(wikiId);
 


### PR DESCRIPTION
## Summary
- add WaitHelper for async polling in tests
- replace fixed Task.Delay calls across integration tests

## Testing
- `dotnet test` *(fails: System.MissingMethodException)*


------
https://chatgpt.com/codex/tasks/task_e_688fec53f5b4832cbcc34a1cc0b23e0d