### PR TITLE
Add AzureDevOpsActionResult with exception handling

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
@@ -1,0 +1,27 @@
+namespace Dotnet.AzureDevOps.Core.Common
+{
+    public class AzureDevOpsActionResult<T>
+    {
+        public bool Success { get; }
+
+        public T? Value { get; }
+
+        public string? Message { get; }
+
+        public Exception? Exception { get; }
+
+        private AzureDevOpsActionResult(bool success, T? value, string? message, Exception? exception)
+        {
+            Success = success;
+            Value = value;
+            Message = message;
+            Exception = exception;
+        }
+
+        public static AzureDevOpsActionResult<T> FromValue(T value)
+            => new AzureDevOpsActionResult<T>(true, value, null, null);
+
+        public static AzureDevOpsActionResult<T> FromException(Exception exception, string? message = null)
+            => new AzureDevOpsActionResult<T>(false, default, message ?? exception.Message, exception);
+    }
+}


### PR DESCRIPTION
## Summary
- add public AzureDevOpsActionResult<T> with value or exception factories

## Testing
- `dotnet test` *(fails: Section 'AZURE_DEVOPS_ORG' not found in configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890b9c9d5bc832c8c9175ad302f8c67