### PR TITLE
feat: return action results for client operations

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
@@ -1,0 +1,27 @@
+using System.Net;
+
+namespace Dotnet.AzureDevOps.Core.Common;
+
+public class AzureDevOpsActionResult<T>
+{
+    public bool IsSuccess { get; }
+    public T? Value { get; }
+    public HttpStatusCode? StatusCode { get; }
+    public string? ErrorMessage { get; }
+
+    private AzureDevOpsActionResult(bool isSuccess, T? value, HttpStatusCode? statusCode, string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Value = value;
+        StatusCode = statusCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public static AzureDevOpsActionResult<T> Success(T value) => new(true, value, null, null);
+
+    public static AzureDevOpsActionResult<T> Failure(HttpStatusCode statusCode, string? errorMessage = null)
+        => new(false, default, statusCode, errorMessage);
+
+    public static AzureDevOpsActionResult<T> Failure(string errorMessage)
+        => new(false, default, null, errorMessage);
+}

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Repos/IReposClient.cs
@@ -1,52 +1,52 @@
-﻿using Dotnet.AzureDevOps.Core.Repos.Options;
+using Dotnet.AzureDevOps.Core.Common;
+using Dotnet.AzureDevOps.Core.Repos.Options;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 
-namespace Dotnet.AzureDevOps.Core.Repos
+namespace Dotnet.AzureDevOps.Core.Repos;
+
+public interface IReposClient
 {
-    public interface IReposClient
-    {
-        Task<GitPullRequest> AbandonPullRequestAsync(string repositoryIdOrName, int pullRequestId);
-        Task<IList<WebApiTagDefinition>> AddLabelsAsync(string repository, int pullRequestId, params string[] labels);
-        Task<bool> AddReviewerAsync(string repositoryId, int pullRequestId, (string localId, string name) reviewer);
-        Task<bool> AddReviewersAsync(string repositoryId, int pullRequestId, (string localId, string name)[] reviewers);
-        Task<GitPullRequest> CompletePullRequestAsync(string repositoryId, int pullRequestId, bool squashMerge = false, bool deleteSourceBranch = false, GitCommitRef? lastMergeSourceCommit = null, string? commitMessage = null);
-        Task<List<GitRefUpdateResult>> CreateBranchAsync(string repositoryId, string newRefName, string baseCommitSha);
-        Task<int> CreateCommentThreadAsync(CommentThreadOptions commentThreadOptions);
-        Task<int?> CreatePullRequestAsync(PullRequestCreateOptions pullRequestCreateOptions);
-        Task<Guid> CreateRepositoryAsync(string newRepositoryName);
-        Task<GitAnnotatedTag> CreateTagAsync(TagCreateOptions tagCreateOptions);
-        Task DeleteCommentAsync(string repositoryId, int pullRequestId, int threadId, int commentId);
-        Task DeleteRepositoryAsync(Guid repositoryId);
-        Task<GitRefUpdateResult?> DeleteTagAsync(string repositoryId, string tagName);
-        Task<Comment> EditCommentAsync(CommentEditOptions commentEditOptions);
-        Task<GitPullRequest> EnableAutoCompleteAsync(string repositoryId, int pullRequestId, string displayName, string localId, GitPullRequestCompletionOptions gitPullRequestCompletionOptions);
-        Task<GitRef?> GetBranchAsync(string repositoryId, string branchName);
-        Task<GitCommitDiffs> GetCommitDiffAsync(string repositoryId, string baseSha, string targetSha);
-        Task<GitPullRequestIterationChanges> GetIterationChangesAsync(string repositoryId, int pullRequestId, int iteration);
-        Task<IReadOnlyList<GitCommitRef>> GetLatestCommitsAsync(string projectName, string repositoryName, string branchName, int top = 1);
-        Task<GitPullRequest?> GetPullRequestAsync(string repositoryId, int pullRequestId);
-        Task<IReadOnlyList<WebApiTagDefinition>> GetPullRequestLabelsAsync(string repository, int pullRequestId);
-        Task<GitRepository?> GetRepositoryAsync(Guid repositoryId);
-        Task<GitRepository?> GetRepositoryByNameAsync(string repositoryName);
-        Task<GitAnnotatedTag> GetTagAsync(string repositoryId, string objectId);
-        Task<IReadOnlyList<GitRef>> ListBranchesAsync(string repositoryId);
-        Task<IReadOnlyList<GitPullRequestIteration>> ListIterationsAsync(string repositoryId, int pullRequestId);
-        Task<IReadOnlyList<GitRef>> ListMyBranchesAsync(string repositoryId);
-        Task<IReadOnlyList<GitPullRequest>> ListPullRequestsAsync(string repositoryId, PullRequestSearchOptions pullRequestSearchOptions);
-        Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByLabelAsync(string repositoryId, string labelName, PullRequestStatus pullRequestStatus);
-        Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByProjectAsync(PullRequestSearchOptions pullRequestSearchOptions);
-        Task<IReadOnlyList<Comment>> ListPullRequestThreadCommentsAsync(string repositoryId, int pullRequestId, int threadId);
-        Task<IReadOnlyList<GitPullRequestCommentThread>> ListPullRequestThreadsAsync(string repositoryId, int pullRequestId);
-        Task<IReadOnlyList<GitRepository>> ListRepositoriesAsync();
-        Task RemoveLabelAsync(string repositoryId, int pullRequestId, string label);
-        Task RemoveReviewersAsync(string repositoryId, int pullRequestId, params string[] reviewerIds);
-        Task<int?> ReplyToCommentThreadAsync(CommentReplyOptions commentReplyOptions);
-        Task<GitPullRequestCommentThread> ResolveCommentThreadAsync(string repositoryId, int pullRequestId, int threadId);
-        Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string repositoryId, GitQueryCommitsCriteria searchCriteria, int top = 100);
-        Task<GitPullRequestStatus> SetPullRequestStatusAsync(string repositoryId, int pullRequestId, PullRequestStatusOptions pullRequestStatusOptions);
-        Task<IdentityRefWithVote> SetReviewerVoteAsync(string repositoryId, int pullRequestId, string reviewerId, short vote);
-        Task<GitPullRequest> UpdatePullRequestAsync(string repositoryId, int pullRequestId, PullRequestUpdateOptions pullRequestUpdateOptions);
-        Task<string> CommitAddFileAsync(FileCommitOptions fileCommitOptions);
-    }
+    Task<GitPullRequest> AbandonPullRequestAsync(string repositoryIdOrName, int pullRequestId);
+    Task<IList<WebApiTagDefinition>> AddLabelsAsync(string repository, int pullRequestId, params string[] labels);
+    Task<AzureDevOpsActionResult<bool>> AddReviewerAsync(string repositoryId, int pullRequestId, (string localId, string name) reviewer);
+    Task<AzureDevOpsActionResult<bool>> AddReviewersAsync(string repositoryId, int pullRequestId, (string localId, string name)[] reviewers);
+    Task<GitPullRequest> CompletePullRequestAsync(string repositoryId, int pullRequestId, bool squashMerge = false, bool deleteSourceBranch = false, GitCommitRef? lastMergeSourceCommit = null, string? commitMessage = null);
+    Task<List<GitRefUpdateResult>> CreateBranchAsync(string repositoryId, string newRefName, string baseCommitSha);
+    Task<int> CreateCommentThreadAsync(CommentThreadOptions commentThreadOptions);
+    Task<int?> CreatePullRequestAsync(PullRequestCreateOptions pullRequestCreateOptions);
+    Task<Guid> CreateRepositoryAsync(string newRepositoryName);
+    Task<GitAnnotatedTag> CreateTagAsync(TagCreateOptions tagCreateOptions);
+    Task DeleteCommentAsync(string repositoryId, int pullRequestId, int threadId, int commentId);
+    Task DeleteRepositoryAsync(Guid repositoryId);
+    Task<GitRefUpdateResult?> DeleteTagAsync(string repositoryId, string tagName);
+    Task<Comment> EditCommentAsync(CommentEditOptions commentEditOptions);
+    Task<GitPullRequest> EnableAutoCompleteAsync(string repositoryId, int pullRequestId, string displayName, string localId, GitPullRequestCompletionOptions gitPullRequestCompletionOptions);
+    Task<GitRef?> GetBranchAsync(string repositoryId, string branchName);
+    Task<GitCommitDiffs> GetCommitDiffAsync(string repositoryId, string baseSha, string targetSha);
+    Task<GitPullRequestIterationChanges> GetIterationChangesAsync(string repositoryId, int pullRequestId, int iteration);
+    Task<IReadOnlyList<GitCommitRef>> GetLatestCommitsAsync(string projectName, string repositoryName, string branchName, int top = 1);
+    Task<GitPullRequest?> GetPullRequestAsync(string repositoryId, int pullRequestId);
+    Task<IReadOnlyList<WebApiTagDefinition>> GetPullRequestLabelsAsync(string repository, int pullRequestId);
+    Task<GitRepository?> GetRepositoryAsync(Guid repositoryId);
+    Task<GitRepository?> GetRepositoryByNameAsync(string repositoryName);
+    Task<GitAnnotatedTag> GetTagAsync(string repositoryId, string objectId);
+    Task<IReadOnlyList<GitRef>> ListBranchesAsync(string repositoryId);
+    Task<IReadOnlyList<GitPullRequestIteration>> ListIterationsAsync(string repositoryId, int pullRequestId);
+    Task<IReadOnlyList<GitRef>> ListMyBranchesAsync(string repositoryId);
+    Task<IReadOnlyList<GitPullRequest>> ListPullRequestsAsync(string repositoryId, PullRequestSearchOptions pullRequestSearchOptions);
+    Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByLabelAsync(string repositoryId, string labelName, PullRequestStatus pullRequestStatus);
+    Task<IReadOnlyList<GitPullRequest>> ListPullRequestsByProjectAsync(PullRequestSearchOptions pullRequestSearchOptions);
+    Task<IReadOnlyList<Comment>> ListPullRequestThreadCommentsAsync(string repositoryId, int pullRequestId, int threadId);
+    Task<IReadOnlyList<GitPullRequestCommentThread>> ListPullRequestThreadsAsync(string repositoryId, int pullRequestId);
+    Task<IReadOnlyList<GitRepository>> ListRepositoriesAsync();
+    Task RemoveLabelAsync(string repositoryId, int pullRequestId, string label);
+    Task RemoveReviewersAsync(string repositoryId, int pullRequestId, params string[] reviewerIds);
+    Task<int?> ReplyToCommentThreadAsync(CommentReplyOptions commentReplyOptions);
+    Task<GitPullRequestCommentThread> ResolveCommentThreadAsync(string repositoryId, int pullRequestId, int threadId);
+    Task<IReadOnlyList<GitCommitRef>> SearchCommitsAsync(string repositoryId, GitQueryCommitsCriteria searchCriteria, int top = 100);
+    Task<GitPullRequestStatus> SetPullRequestStatusAsync(string repositoryId, int pullRequestId, PullRequestStatusOptions pullRequestStatusOptions);
+    Task<IdentityRefWithVote> SetReviewerVoteAsync(string repositoryId, int pullRequestId, string reviewerId, short vote);
+    Task<GitPullRequest> UpdatePullRequestAsync(string repositoryId, int pullRequestId, PullRequestUpdateOptions pullRequestUpdateOptions);
+    Task<string> CommitAddFileAsync(FileCommitOptions fileCommitOptions);
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Search/ISearchClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Search/ISearchClient.cs
@@ -1,10 +1,12 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.Search.Options;
 
 namespace Dotnet.AzureDevOps.Core.Search;
 
 public interface ISearchClient
 {
-    Task<string> SearchCodeAsync(CodeSearchOptions options, CancellationToken cancellationToken = default);
-    Task<string> SearchWikiAsync(WikiSearchOptions options, CancellationToken cancellationToken = default);
-    Task<string> SearchWorkItemsAsync(WorkItemSearchOptions options, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<string>> SearchCodeAsync(CodeSearchOptions options, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<string>> SearchWikiAsync(WikiSearchOptions options, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<string>> SearchWorkItemsAsync(WorkItemSearchOptions options, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> IsCodeSearchEnabledAsync(CancellationToken cancellationToken = default);
 }

--- a/test/unit.tests/Dotnet.AzureDevOps.Search.Tests/Dotnet.AzureDevOps.Search.Tests.csproj
+++ b/test/unit.tests/Dotnet.AzureDevOps.Search.Tests/Dotnet.AzureDevOps.Search.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Search/Dotnet.AzureDevOps.Core.Search.csproj" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/test/unit.tests/Dotnet.AzureDevOps.Search.Tests/SearchClientTests.cs
+++ b/test/unit.tests/Dotnet.AzureDevOps.Search.Tests/SearchClientTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using Dotnet.AzureDevOps.Core.Search;
+using Dotnet.AzureDevOps.Core.Search.Options;
+using Dotnet.AzureDevOps.Core.Common;
+
+public class SearchClientTests
+{
+    private static HttpClient CreateClient(HttpStatusCode statusCode, string content)
+    {
+        var handler = new StubHandler((request, ct) =>
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content)
+            };
+            return Task.FromResult(response);
+        });
+        return new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+    }
+
+    [Fact]
+    public async Task SearchWikiAsync_ReturnsSuccess_OnHttp200()
+    {
+        HttpClient httpClient = CreateClient(HttpStatusCode.OK, "result");
+        var client = new SearchClient("org", "pat", httpClient);
+        var result = await client.SearchWikiAsync(new WikiSearchOptions { SearchText = "foo" });
+        Assert.True(result.IsSuccess);
+        Assert.Equal("result", result.Value);
+    }
+
+    [Fact]
+    public async Task SearchWikiAsync_ReturnsFailure_OnHttpError()
+    {
+        HttpClient httpClient = CreateClient(HttpStatusCode.InternalServerError, "bad");
+        var client = new SearchClient("org", "pat", httpClient);
+        var result = await client.SearchWikiAsync(new WikiSearchOptions { SearchText = "foo" });
+        Assert.False(result.IsSuccess);
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AzureDevOpsActionResult<T>` for result-based client responses
- update search and repos clients to surface success/failure instead of throwing
- cover search client with unit tests for success and failure scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c9c17d3c832cba168483cea6c357