### PR TITLE
Use AzureDevOpsActionResult in test plans client

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.TestPlans/ITestPlansClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.TestPlans/ITestPlansClient.cs
@@ -1,4 +1,5 @@
-﻿using Dotnet.AzureDevOps.Core.TestPlans.Options;
+﻿using Dotnet.AzureDevOps.Core.Common;
+using Dotnet.AzureDevOps.Core.TestPlans.Options;
 using Microsoft.TeamFoundation.TestManagement.WebApi;
 using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
@@ -7,16 +8,16 @@ namespace Dotnet.AzureDevOps.Core.TestPlans
 {
     public interface ITestPlansClient
     {
-        Task AddTestCasesAsync(int testPlanId, int testSuiteId, IReadOnlyList<int> testCaseIds, CancellationToken cancellationToken = default);
-        Task<Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem?> CreateTestCaseAsync(TestCaseCreateOptions options, CancellationToken cancellationToken = default);
-        Task<int> CreateTestPlanAsync(TestPlanCreateOptions testPlanCreateOptions, CancellationToken cancellationToken = default);
-        Task<int> CreateTestSuiteAsync(int testPlanId, TestSuiteCreateOptions testSuiteCreateOptions, CancellationToken cancellationToken = default);
-        Task DeleteTestPlanAsync(int testPlanId, CancellationToken cancellationToken = default);
-        Task<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite> GetRootSuiteAsync(int planId);
-        Task<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan?> GetTestPlanAsync(int testPlanId, CancellationToken cancellationToken = default);
-        Task<TestResultsDetails?> GetTestResultsForBuildAsync(string projectName, int buildId, CancellationToken cancellationToken = default);
-        Task<PagedList<TestCase>> ListTestCasesAsync(int testPlanId, int testSuiteId, CancellationToken cancellationToken = default);
-        Task<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan>> ListTestPlansAsync(CancellationToken cancellationToken = default);
-        Task<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite>> ListTestSuitesAsync(int testPlanId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<bool>> AddTestCasesAsync(int testPlanId, int testSuiteId, IReadOnlyList<int> testCaseIds, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem?>> CreateTestCaseAsync(TestCaseCreateOptions options, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<int>> CreateTestPlanAsync(TestPlanCreateOptions testPlanCreateOptions, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<int>> CreateTestSuiteAsync(int testPlanId, TestSuiteCreateOptions testSuiteCreateOptions, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<bool>> DeleteTestPlanAsync(int testPlanId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite>> GetRootSuiteAsync(int planId);
+        Task<AzureDevOpsActionResult<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan?>> GetTestPlanAsync(int testPlanId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<TestResultsDetails>> GetTestResultsForBuildAsync(string projectName, int buildId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<PagedList<TestCase>>> ListTestCasesAsync(int testPlanId, int testSuiteId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan>>> ListTestPlansAsync(CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite>>> ListTestSuitesAsync(int testPlanId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.TestPlans/TestPlansClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.TestPlans/TestPlansClient.cs
@@ -10,6 +10,9 @@ using Microsoft.VisualStudio.Services.WebApi.Patch;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
 using System.Linq;
 using WorkItem = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.WorkItem;
+using TestSuite = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite;
+using TestPlan = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan;
+using PointAssignment = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.PointAssignment;
 
 namespace Dotnet.AzureDevOps.Core.TestPlans;
 
@@ -152,15 +155,15 @@ public class TestPlansClient : ITestPlansClient
     {
         try
         {
-            List<WorkItem> references = testCaseIds.Select(id => new WorkItem { Id = id }).ToList();
-            List<SuiteTestCaseCreateUpdateParameters> existingTestCases = new List<SuiteTestCaseCreateUpdateParameters>();
+            var references = testCaseIds.Select(id => new WorkItem { Id = id }).ToList();
+            var existingTestCases = new List<SuiteTestCaseCreateUpdateParameters>();
 
             foreach(WorkItem workItem in references)
             {
                 SuiteTestCaseCreateUpdateParameters suiteTestCase = new SuiteTestCaseCreateUpdateParameters
                 {
                     workItem = new WorkItem { Id = workItem.Id },
-                    PointAssignments = Array.Empty<PointAssignment>()
+                    PointAssignments = []
                 };
                 existingTestCases.Add(suiteTestCase);
             }
@@ -184,9 +187,9 @@ public class TestPlansClient : ITestPlansClient
     {
         try
         {
-            WorkItemTrackingHttpClient workItemTracking = new WorkItemTrackingHttpClient(_connection.Uri, _connection.Credentials);
+            var workItemTracking = new WorkItemTrackingHttpClient(_connection.Uri, _connection.Credentials);
 
-            JsonPatchDocument patch = new JsonPatchDocument
+            var patch = new JsonPatchDocument
             {
                 new JsonPatchOperation { Operation = Operation.Add, Path = "/fields/System.Title", Value = options.Title }
             };
@@ -274,16 +277,16 @@ public class TestPlansClient : ITestPlansClient
         try
         {
             AzureDevOpsActionResult<IReadOnlyList<TestSuite>> suitesResult = await ListTestSuitesAsync(planId);
-            if(!suitesResult.IsSuccessful || suitesResult.Value == null)
+            if (!suitesResult.IsSuccessful || suitesResult.Value == null)
                 return AzureDevOpsActionResult<TestSuite>.Failure(suitesResult.ErrorMessage ?? $"Unable to list suites for plan {planId}.");
 
             IReadOnlyList<TestSuite> suites = suitesResult.Value;
             TestSuite? root = suites.FirstOrDefault(suite => suite.ParentSuite == null || suite.ParentSuite.Id != -1);
-            return root == null
+            return root is null
                 ? AzureDevOpsActionResult<TestSuite>.Failure($"No root suite found for test plan {planId}.")
                 : AzureDevOpsActionResult<TestSuite>.Success(root);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return AzureDevOpsActionResult<TestSuite>.Failure(ex);
         }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.TestPlans;
 using Dotnet.AzureDevOps.Core.TestPlans.Options;
 using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
@@ -16,58 +17,80 @@ public class TestPlansTools
         => new(organizationUrl, projectName, personalAccessToken);
 
     [McpServerTool, Description("Creates a test plan.")]
-    public static Task<int> CreateTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, TestPlanCreateOptions options)
+    public static async Task<int> CreateTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, TestPlanCreateOptions options)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateTestPlanAsync(options);
+        AzureDevOpsActionResult<int> result = await client.CreateTestPlanAsync(options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to create test plan.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Retrieves a test plan.")]
-    public static Task<TestPlan?> GetTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
+    public static async Task<TestPlan?> GetTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetTestPlanAsync(testPlanId);
+        AzureDevOpsActionResult<TestPlan?> result = await client.GetTestPlanAsync(testPlanId);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists test plans.")]
-    public static Task<IReadOnlyList<TestPlan>> ListTestPlansAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<IReadOnlyList<TestPlan>> ListTestPlansAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListTestPlansAsync();
+        AzureDevOpsActionResult<IReadOnlyList<TestPlan>> result = await client.ListTestPlansAsync();
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list test plans.");
+        return result.Value ?? Array.Empty<TestPlan>();
     }
 
     [McpServerTool, Description("Deletes a test plan.")]
-    public static Task DeleteTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
+    public static async Task DeleteTestPlanAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeleteTestPlanAsync(testPlanId);
+        AzureDevOpsActionResult<bool> result = await client.DeleteTestPlanAsync(testPlanId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to delete test plan.");
     }
 
     [McpServerTool, Description("Creates a test suite.")]
-    public static Task<int> CreateTestSuiteAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId, TestSuiteCreateOptions options)
+    public static async Task<int> CreateTestSuiteAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId, TestSuiteCreateOptions options)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateTestSuiteAsync(testPlanId, options);
+        AzureDevOpsActionResult<int> result = await client.CreateTestSuiteAsync(testPlanId, options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to create test suite.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists test suites for a plan.")]
-    public static Task<IReadOnlyList<TestSuite>> ListTestSuitesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
+    public static async Task<IReadOnlyList<TestSuite>> ListTestSuitesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListTestSuitesAsync(testPlanId);
+        AzureDevOpsActionResult<IReadOnlyList<TestSuite>> result = await client.ListTestSuitesAsync(testPlanId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list test suites.");
+        return result.Value ?? Array.Empty<TestSuite>();
     }
 
     [McpServerTool, Description("Adds test cases to a suite.")]
-    public static Task AddTestCasesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId, int testSuiteId, IReadOnlyList<int> testCaseIds)
+    public static async Task AddTestCasesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId, int testSuiteId, IReadOnlyList<int> testCaseIds)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.AddTestCasesAsync(testPlanId, testSuiteId, testCaseIds);
+        AzureDevOpsActionResult<bool> result = await client.AddTestCasesAsync(testPlanId, testSuiteId, testCaseIds);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to add test cases.");
     }
 
     [McpServerTool, Description("Gets the root suite of a test plan.")]
-    public static Task<TestSuite> GetRootSuiteAsync(string organizationUrl, string projectName, string personalAccessToken, int planId)
+    public static async Task<TestSuite?> GetRootSuiteAsync(string organizationUrl, string projectName, string personalAccessToken, int planId)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetRootSuiteAsync(planId);
+        AzureDevOpsActionResult<TestSuite> result = await client.GetRootSuiteAsync(planId);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
@@ -69,8 +69,8 @@ public class TestPlansTools
     public static async Task<IReadOnlyList<TestSuite>> ListTestSuitesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId)
     {
         TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        AzureDevOpsActionResult<IReadOnlyList<TestSuite>> result = await client.ListTestSuitesAsync(testPlanId);
-        if(!result.IsSuccessful)
+        AzureDevOpsActionResult<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite>> result = await client.ListTestSuitesAsync(testPlanId);
+        if (!result.IsSuccessful)
             throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list test suites.");
         return result.Value ?? Array.Empty<TestSuite>();
     }

--- a/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
@@ -8,6 +8,9 @@ using Dotnet.AzureDevOps.Tests.Common;
 using Dotnet.AzureDevOps.Tests.Common.Attributes;
 using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
 using Microsoft.VisualStudio.Services.TestResults.WebApi;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
+using TestSuite = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite;
+using TestPlan = Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestPlan;
 
 namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
 {
@@ -91,7 +94,7 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
             Assert.True(suiteResult.IsSuccessful);
             int suiteId = suiteResult.Value;
 
-            AzureDevOpsActionResult<IReadOnlyList<TestSuite>> listSuitesResult = await _testPlansClient.ListTestSuitesAsync(planId);
+            AzureDevOpsActionResult<IReadOnlyList<Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite>> listSuitesResult = await _testPlansClient.ListTestSuitesAsync(planId);
             Assert.True(listSuitesResult.IsSuccessful);
             IReadOnlyList<TestSuite> suites = listSuitesResult.Value!;
             Assert.Contains(suites, s => s.Id == suiteId);

--- a/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.TestPlans.IntegrationTests/DotnetAzureDevOpsTestPlansIntegrationTests.cs
@@ -1,3 +1,4 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.TestPlans;
 using Dotnet.AzureDevOps.Core.TestPlans.Options;
 using Dotnet.AzureDevOps.Core.Pipelines;
@@ -17,8 +18,8 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
         private readonly TestPlansClient _testPlansClient;
         private readonly PipelinesClient _pipelinesClient;
-        private readonly List<int> _createdPlanIds = [];
-        private readonly List<int> _queuedBuildIds = [];
+        private readonly List<int> _createdPlanIds = new List<int>();
+        private readonly List<int> _queuedBuildIds = new List<int>();
 
         public DotnetAzureDevOpsTestPlansIntegrationTests(IntegrationTestFixture fixture)
         {
@@ -31,42 +32,53 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
         [Fact]
         public async Task PlanCrud_SucceedsAsync()
         {
-            var create = new TestPlanCreateOptions
+            TestPlanCreateOptions create = new TestPlanCreateOptions
             {
                 Name = $"it-plan-{UtcStamp()}",
-                Description = "Created by integration test"
+                Description = "Created by integration test",
             };
 
-            int planId = await _testPlansClient.CreateTestPlanAsync(create);
+            AzureDevOpsActionResult<int> createResult = await _testPlansClient.CreateTestPlanAsync(create);
+            Assert.True(createResult.IsSuccessful);
+            int planId = createResult.Value;
             _createdPlanIds.Add(planId);
 
-            TestPlan? read = await _testPlansClient.GetTestPlanAsync(planId);
+            AzureDevOpsActionResult<TestPlan?> readResult = await _testPlansClient.GetTestPlanAsync(planId);
+            Assert.True(readResult.IsSuccessful);
+            TestPlan? read = readResult.Value;
             Assert.NotNull(read);
             Assert.Equal(create.Name, read!.Name);
 
-            IReadOnlyList<TestPlan> list = await _testPlansClient.ListTestPlansAsync();
+            AzureDevOpsActionResult<IReadOnlyList<TestPlan>> listResult = await _testPlansClient.ListTestPlansAsync();
+            Assert.True(listResult.IsSuccessful);
+            IReadOnlyList<TestPlan> list = listResult.Value!;
             Assert.Contains(list, p => p.Id == planId);
 
-            await _testPlansClient.DeleteTestPlanAsync(planId);
+            AzureDevOpsActionResult<bool> deleteResult = await _testPlansClient.DeleteTestPlanAsync(planId);
+            Assert.True(deleteResult.IsSuccessful);
             _createdPlanIds.Remove(planId);
 
-            TestPlan? afterDelete = await _testPlansClient.GetTestPlanAsync(planId);
-            Assert.Null(afterDelete);
+            AzureDevOpsActionResult<TestPlan?> afterDeleteResult = await _testPlansClient.GetTestPlanAsync(planId);
+            Assert.True(afterDeleteResult.IsSuccessful);
+            Assert.Null(afterDeleteResult.Value);
         }
 
         [Fact]
         public async Task SuiteCrud_SucceedsAsync()
         {
-            int planId = await _testPlansClient.CreateTestPlanAsync(new TestPlanCreateOptions
+            AzureDevOpsActionResult<int> planResult = await _testPlansClient.CreateTestPlanAsync(new TestPlanCreateOptions
             {
                 Name = $"it-plan-{UtcStamp()}"
             });
+            Assert.True(planResult.IsSuccessful);
+            int planId = planResult.Value;
             _createdPlanIds.Add(planId);
 
-            // Retrieve root suite of the test plan (usually ID = 1, but safer to fetch dynamically)
-            TestSuite rootSuite = await _testPlansClient.GetRootSuiteAsync(planId);
+            AzureDevOpsActionResult<TestSuite> rootSuiteResult = await _testPlansClient.GetRootSuiteAsync(planId);
+            Assert.True(rootSuiteResult.IsSuccessful);
+            TestSuite rootSuite = rootSuiteResult.Value!;
 
-            var suiteCreate = new TestSuiteCreateOptions
+            TestSuiteCreateOptions suiteCreate = new TestSuiteCreateOptions
             {
                 Name = $"it-suite-{UtcStamp()}",
                 ParentSuite = new TestSuiteReference
@@ -75,35 +87,50 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
                 }
             };
 
-            int suiteId = await _testPlansClient.CreateTestSuiteAsync(planId, suiteCreate);
+            AzureDevOpsActionResult<int> suiteResult = await _testPlansClient.CreateTestSuiteAsync(planId, suiteCreate);
+            Assert.True(suiteResult.IsSuccessful);
+            int suiteId = suiteResult.Value;
 
-            IReadOnlyList<TestSuite> suites = await _testPlansClient.ListTestSuitesAsync(planId);
+            AzureDevOpsActionResult<IReadOnlyList<TestSuite>> listSuitesResult = await _testPlansClient.ListTestSuitesAsync(planId);
+            Assert.True(listSuitesResult.IsSuccessful);
+            IReadOnlyList<TestSuite> suites = listSuitesResult.Value!;
             Assert.Contains(suites, s => s.Id == suiteId);
         }
 
         [Fact]
         public async Task TestCaseCreateAndAdd_SucceedsAsync()
         {
-            int planId = await _testPlansClient.CreateTestPlanAsync(new TestPlanCreateOptions
+            AzureDevOpsActionResult<int> planResult = await _testPlansClient.CreateTestPlanAsync(new TestPlanCreateOptions
             {
                 Name = $"it-plan-{UtcStamp()}"
             });
+            Assert.True(planResult.IsSuccessful);
+            int planId = planResult.Value;
             _createdPlanIds.Add(planId);
 
-            TestSuite rootSuite = await _testPlansClient.GetRootSuiteAsync(planId);
+            AzureDevOpsActionResult<TestSuite> rootResult = await _testPlansClient.GetRootSuiteAsync(planId);
+            Assert.True(rootResult.IsSuccessful);
+            TestSuite rootSuite = rootResult.Value!;
 
-            Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem? testCase = await _testPlansClient.CreateTestCaseAsync(
-                new TestCaseCreateOptions
-                {
-                    Title = "Integration Test Case",
-                    Project = _azureDevOpsConfiguration.ProjectName
-                });
+            AzureDevOpsActionResult<Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem?> testCaseResult =
+                await _testPlansClient.CreateTestCaseAsync(
+                    new TestCaseCreateOptions
+                    {
+                        Title = "Integration Test Case",
+                        Project = _azureDevOpsConfiguration.ProjectName
+                    });
+            Assert.True(testCaseResult.IsSuccessful);
+            Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem? testCase = testCaseResult.Value;
             Assert.NotNull(testCase);
 
-            await _testPlansClient.AddTestCasesAsync(planId, rootSuite.Id, [testCase!.Id!.Value]);
+            AzureDevOpsActionResult<bool> addResult =
+                await _testPlansClient.AddTestCasesAsync(planId, rootSuite.Id, new List<int> { testCase!.Id!.Value });
+            Assert.True(addResult.IsSuccessful);
 
-            Microsoft.VisualStudio.Services.WebApi.PagedList<TestCase> list = await _testPlansClient.ListTestCasesAsync(planId, rootSuite.Id);
-
+            AzureDevOpsActionResult<Microsoft.VisualStudio.Services.WebApi.PagedList<TestCase>> listResult =
+                await _testPlansClient.ListTestCasesAsync(planId, rootSuite.Id);
+            Assert.True(listResult.IsSuccessful);
+            Microsoft.VisualStudio.Services.WebApi.PagedList<TestCase> list = listResult.Value!;
             Assert.Contains(list, w => w.workItem.Id == testCase.Id);
         }
 
@@ -117,11 +144,12 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
             });
             _queuedBuildIds.Add(buildId);
 
-            Microsoft.TeamFoundation.TestManagement.WebApi.TestResultsDetails? details = await _testPlansClient.GetTestResultsForBuildAsync(
+            AzureDevOpsActionResult<TestResultsDetails> detailsResult = await _testPlansClient.GetTestResultsForBuildAsync(
                 _azureDevOpsConfiguration.ProjectName,
                 buildId);
 
-            Assert.NotNull(details);
+            Assert.True(detailsResult.IsSuccessful);
+            Assert.NotNull(detailsResult.Value);
         }
 
         private static string UtcStamp() =>
@@ -134,7 +162,9 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
             foreach(int id in _createdPlanIds.AsEnumerable().Reverse())
             {
                 try
-                { await _testPlansClient.DeleteTestPlanAsync(id); }
+                {
+                    _ = await _testPlansClient.DeleteTestPlanAsync(id);
+                }
                 catch
                 {
                     // Ignore errors during cleanup; the test plan may have already been deleted or not exist
@@ -157,3 +187,4 @@ namespace Dotnet.AzureDevOps.TestPlans.IntegrationTests
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- return `AzureDevOpsActionResult` from all TestPlansClient APIs
- adjust TestPlans tools and integration tests for new result type

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68912f2dc3d4832c814bb6e3b362805c