### PR TITLE
Use AzureDevOpsActionResult in Artifacts client

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/ArtifactsClient.cs
@@ -1,13 +1,15 @@
-﻿using System.Net.Http.Headers;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
 using Dotnet.AzureDevOps.Core.Common;
-
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;
 
@@ -22,225 +24,390 @@ public class ArtifactsClient : IArtifactsClient
     public ArtifactsClient(string organizationUrl, string projectName, string personalAccessToken)
     {
         _projectName = projectName.TrimEnd('/');
-
         _organizationUrl = organizationUrl.Replace("https://dev.azure.com", "https://feeds.dev.azure.com");
-
         _httpClient = new HttpClient { BaseAddress = new Uri(organizationUrl) };
-
         string encodedPersonalAccessToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{personalAccessToken}"));
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", encodedPersonalAccessToken);
-
     }
 
-    public async Task<Guid> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default)
+    public async Task<AzureDevOpsActionResult<Guid>> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default)
     {
-        string feedsUrl = $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds?api-version={ApiVersion}";
-        var payload = new { name = feedCreateOptions.Name, description = feedCreateOptions.Description };
-        HttpResponseMessage httpResponseMessage = await System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync(
-            _httpClient,
-            feedsUrl,
-            payload,
-            cancellationToken);
-        httpResponseMessage.EnsureSuccessStatusCode();
-        Feed? feed = await httpResponseMessage.Content.ReadFromJsonAsync<Feed>(cancellationToken);
-        return feed!.Id;
-    }
-
-    public async Task UpdateFeedAsync(Guid feedId, FeedUpdateOptions feedUpdateOptions, CancellationToken cancellationToken = default)
-    {
-        var fields = new Dictionary<string, string?>();
-        if(feedUpdateOptions.Name is { Length: > 0 })
-            fields["name"] = feedUpdateOptions.Name;
-        if(feedUpdateOptions.Description is { Length: > 0 })
-            fields["description"] = feedUpdateOptions.Description;
-        if(fields.Count == 0)
-            return;
-
-        var requestMessage = new HttpRequestMessage(HttpMethod.Patch,
-            $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}")
+        try
         {
-            Content = JsonContent.Create(fields)
-        };
-        HttpResponseMessage response = await _httpClient.SendAsync(
-            request: requestMessage,
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-    }
-
-    public async Task<Feed?> GetFeedAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        if(response.StatusCode == System.Net.HttpStatusCode.NotFound)
-            return null;
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Feed>(cancellationToken);
-    }
-
-    public async Task<IReadOnlyList<Feed>> ListFeedsAsync(CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        FeedList? list = await response.Content.ReadFromJsonAsync<FeedList>(cancellationToken);
-        return list?.Value?.ToArray() ?? [];
-    }
-
-    public async Task DeleteFeedAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.DeleteAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-    }
-
-    public async Task<IReadOnlyList<Package>> ListPackagesAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/packages?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        PackageList? list = await response.Content.ReadFromJsonAsync<PackageList>(cancellationToken);
-        return list?.Value as IReadOnlyList<Package> ?? [];
-    }
-
-    public async Task DeletePackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.DeleteAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/packages/{packageName}/versions/{version}?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-    }
-
-    public async Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        var options = new JsonSerializerOptions
+            string feedsUrl = $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds?api-version={ApiVersion}";
+            object payload = new { name = feedCreateOptions.Name, description = feedCreateOptions.Description };
+            HttpResponseMessage response = await HttpClientJsonExtensions.PostAsJsonAsync(_httpClient, feedsUrl, payload, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<Guid>.Failure(response.StatusCode, error);
+            }
+            Feed? feed = await response.Content.ReadFromJsonAsync<Feed>(cancellationToken);
+            return AzureDevOpsActionResult<Guid>.Success(feed!.Id);
+        }
+        catch(Exception ex)
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true,
-            WriteIndented = true
-        };
-
-        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false));
-
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/permissions?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        FeedPermissionList? list = await response.Content.ReadFromJsonAsync<FeedPermissionList>(options, cancellationToken);
-        return list?.Value?.ToArray() ?? [];
+            return AzureDevOpsActionResult<Guid>.Failure(ex);
+        }
     }
 
-    public async Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default)
+    public async Task<AzureDevOpsActionResult<bool>> UpdateFeedAsync(Guid feedId, FeedUpdateOptions feedUpdateOptions, CancellationToken cancellationToken = default)
     {
-        var options = new JsonSerializerOptions
+        try
         {
-            PropertyNameCaseInsensitive = true
-        };
+            Dictionary<string, string?> fields = new Dictionary<string, string?>();
+            if(feedUpdateOptions.Name is { Length: > 0 })
+            {
+                fields["name"] = feedUpdateOptions.Name;
+            }
+            if(feedUpdateOptions.Description is { Length: > 0 })
+            {
+                fields["description"] = feedUpdateOptions.Description;
+            }
+            if(fields.Count == 0)
+            {
+                return AzureDevOpsActionResult<bool>.Success(true);
+            }
 
-        HttpResponseMessage response = await System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync(
-            _httpClient,
-            $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views?api-version={ApiVersion}",
-            feedView,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return (await response.Content.ReadFromJsonAsync<FeedView>(options, cancellationToken))!;
-    }
-
-    public async Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        FeedViewList? list = await response.Content.ReadFromJsonAsync<FeedViewList>(cancellationToken);
-        return list?.Value?.ToArray() ?? [];
-    }
-
-    public async Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.DeleteAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views/{viewId}?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-    }
-
-    public async Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await System.Net.Http.Json.HttpClientJsonExtensions.PutAsJsonAsync(
-            _httpClient,
-            $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}",
-            behavior,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
-    }
-
-    public async Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return (await response.Content.ReadFromJsonAsync<UpstreamingBehavior>(cancellationToken))!;
-    }
-
-    public async Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return (await response.Content.ReadFromJsonAsync<Package>(cancellationToken))!;
-    }
-
-    public async Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default)
-    {
-        var request = new HttpRequestMessage(HttpMethod.Patch,
-            $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}")
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Patch, $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}")
+            {
+                Content = JsonContent.Create(fields)
+            };
+            HttpResponseMessage response = await _httpClient.SendAsync(requestMessage, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
         {
-            Content = JsonContent.Create(details)
-        };
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
     }
 
-    public async Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    public async Task<AzureDevOpsActionResult<Feed>> GetFeedAsync(Guid feedId, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}/content?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStreamAsync(cancellationToken);
-    }
-
-    public async Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(
-            requestUri: $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/retentionpolicies?api-version={ApiVersion}",
-            cancellationToken: cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        return (await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(cancellationToken))!;
-    }
-
-    public async Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default)
-    {
-        var options = new JsonSerializerOptions
+        try
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = true,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-        };
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<Feed>.Failure(response.StatusCode, error);
+            }
+            Feed? feed = await response.Content.ReadFromJsonAsync<Feed>(cancellationToken);
+            return AzureDevOpsActionResult<Feed>.Success(feed!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<Feed>.Failure(ex);
+        }
+    }
 
-        HttpResponseMessage response = await System.Net.Http.Json.HttpClientJsonExtensions.PutAsJsonAsync(
-            _httpClient,
-            $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/retentionpolicies?api-version={ApiVersion}",
-            policy,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return (await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(options, cancellationToken))!;
+    public async Task<AzureDevOpsActionResult<IReadOnlyList<Feed>>> ListFeedsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<IReadOnlyList<Feed>>.Failure(response.StatusCode, error);
+            }
+            FeedList? list = await response.Content.ReadFromJsonAsync<FeedList>(cancellationToken);
+            IReadOnlyList<Feed> feeds = list?.Value?.ToArray() ?? Array.Empty<Feed>();
+            return AzureDevOpsActionResult<IReadOnlyList<Feed>>.Success(feeds);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<IReadOnlyList<Feed>>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<bool>> DeleteFeedAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.DeleteAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<IReadOnlyList<Package>>> ListPackagesAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/packages?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<IReadOnlyList<Package>>.Failure(response.StatusCode, error);
+            }
+            PackageList? list = await response.Content.ReadFromJsonAsync<PackageList>(cancellationToken);
+            IReadOnlyList<Package> packages = list?.Value?.ToArray() ?? Array.Empty<Package>();
+            return AzureDevOpsActionResult<IReadOnlyList<Package>>.Success(packages);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<IReadOnlyList<Package>>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<bool>> DeletePackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.DeleteAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/packages/{packageName}/versions/{version}?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<IReadOnlyList<FeedPermission>>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNameCaseInsensitive = true,
+                WriteIndented = true
+            };
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/permissions?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<IReadOnlyList<FeedPermission>>.Failure(response.StatusCode, error);
+            }
+            FeedPermissionList? list = await response.Content.ReadFromJsonAsync<FeedPermissionList>(options, cancellationToken);
+            IReadOnlyList<FeedPermission> permissions = list?.Value?.ToArray() ?? Array.Empty<FeedPermission>();
+            return AzureDevOpsActionResult<IReadOnlyList<FeedPermission>>.Success(permissions);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<IReadOnlyList<FeedPermission>>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<FeedView>> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            HttpResponseMessage response = await HttpClientJsonExtensions.PostAsJsonAsync(_httpClient, $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views?api-version={ApiVersion}", feedView, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<FeedView>.Failure(response.StatusCode, error);
+            }
+            FeedView? created = await response.Content.ReadFromJsonAsync<FeedView>(options, cancellationToken);
+            return AzureDevOpsActionResult<FeedView>.Success(created!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<FeedView>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<IReadOnlyList<FeedView>>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<IReadOnlyList<FeedView>>.Failure(response.StatusCode, error);
+            }
+            FeedViewList? list = await response.Content.ReadFromJsonAsync<FeedViewList>(cancellationToken);
+            IReadOnlyList<FeedView> views = list?.Value?.ToArray() ?? Array.Empty<FeedView>();
+            return AzureDevOpsActionResult<IReadOnlyList<FeedView>>.Success(views);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<IReadOnlyList<FeedView>>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<bool>> DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.DeleteAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/views/{viewId}?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<bool>> SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await HttpClientJsonExtensions.PutAsJsonAsync(_httpClient, $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}", behavior, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<UpstreamingBehavior>> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/upstreamingbehavior?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<UpstreamingBehavior>.Failure(response.StatusCode, error);
+            }
+            UpstreamingBehavior? behavior = await response.Content.ReadFromJsonAsync<UpstreamingBehavior>(cancellationToken);
+            return AzureDevOpsActionResult<UpstreamingBehavior>.Success(behavior!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<UpstreamingBehavior>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<Package>> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<Package>.Failure(response.StatusCode, error);
+            }
+            Package? package = await response.Content.ReadFromJsonAsync<Package>(cancellationToken);
+            return AzureDevOpsActionResult<Package>.Success(package!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<Package>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<bool>> UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}?api-version={ApiVersion}")
+            {
+                Content = JsonContent.Create(details)
+            };
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<bool>.Failure(response.StatusCode, error);
+            }
+            return AzureDevOpsActionResult<bool>.Success(true);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<bool>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<Stream>> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/nuget/packages/{packageName}/versions/{version}/content?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<Stream>.Failure(response.StatusCode, error);
+            }
+            Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            return AzureDevOpsActionResult<Stream>.Success(contentStream);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<Stream>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<FeedRetentionPolicy>> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/retentionpolicies?api-version={ApiVersion}", cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<FeedRetentionPolicy>.Failure(response.StatusCode, error);
+            }
+            FeedRetentionPolicy? policy = await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(cancellationToken);
+            return AzureDevOpsActionResult<FeedRetentionPolicy>.Success(policy!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<FeedRetentionPolicy>.Failure(ex);
+        }
+    }
+
+    public async Task<AzureDevOpsActionResult<FeedRetentionPolicy>> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+            };
+            HttpResponseMessage response = await HttpClientJsonExtensions.PutAsJsonAsync(_httpClient, $"{_organizationUrl}/{_projectName}/_apis/packaging/Feeds/{feedId}/retentionpolicies?api-version={ApiVersion}", policy, cancellationToken);
+            if(!response.IsSuccessStatusCode)
+            {
+                string error = await response.Content.ReadAsStringAsync(cancellationToken);
+                return AzureDevOpsActionResult<FeedRetentionPolicy>.Failure(response.StatusCode, error);
+            }
+            FeedRetentionPolicy? updated = await response.Content.ReadFromJsonAsync<FeedRetentionPolicy>(options, cancellationToken);
+            return AzureDevOpsActionResult<FeedRetentionPolicy>.Success(updated!);
+        }
+        catch(Exception ex)
+        {
+            return AzureDevOpsActionResult<FeedRetentionPolicy>.Failure(ex);
+        }
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Artifacts/IArtifactsClient.cs
@@ -1,43 +1,48 @@
-﻿using Dotnet.AzureDevOps.Core.Artifacts.Models;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
+using Dotnet.AzureDevOps.Core.Common;
 
 namespace Dotnet.AzureDevOps.Core.Artifacts;
 
 public interface IArtifactsClient
 {
-    Task<Guid> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<Guid>> CreateFeedAsync(FeedCreateOptions feedCreateOptions, CancellationToken cancellationToken = default);
 
-    Task UpdateFeedAsync(Guid feedId, FeedUpdateOptions feedUpdateOptions, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> UpdateFeedAsync(Guid feedId, FeedUpdateOptions feedUpdateOptions, CancellationToken cancellationToken = default);
 
-    Task<Feed?> GetFeedAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<Feed>> GetFeedAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<Feed>> ListFeedsAsync(CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<IReadOnlyList<Feed>>> ListFeedsAsync(CancellationToken cancellationToken = default);
 
-    Task DeleteFeedAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> DeleteFeedAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<Package>> ListPackagesAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<IReadOnlyList<Package>>> ListPackagesAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task DeletePackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> DeletePackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<IReadOnlyList<FeedPermission>>> GetFeedPermissionsAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task<FeedView> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<FeedView>> CreateFeedViewAsync(Guid feedId, FeedView feedView, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<IReadOnlyList<FeedView>>> ListFeedViewsAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> DeleteFeedViewAsync(Guid feedId, string viewId, CancellationToken cancellationToken = default);
 
-    Task SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> SetUpstreamingBehaviorAsync(Guid feedId, string packageName, UpstreamingBehavior behavior, CancellationToken cancellationToken = default);
 
-    Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<UpstreamingBehavior>> GetUpstreamingBehaviorAsync(Guid feedId, string packageName, CancellationToken cancellationToken = default);
 
-    Task<Package> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<Package>> GetPackageVersionAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
 
-    Task UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<bool>> UpdatePackageVersionAsync(Guid feedId, string packageName, string version, PackageVersionDetails details, CancellationToken cancellationToken = default);
 
-    Task<Stream> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<Stream>> DownloadPackageAsync(Guid feedId, string packageName, string version, CancellationToken cancellationToken = default);
 
-    Task<FeedRetentionPolicy> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<FeedRetentionPolicy>> GetRetentionPolicyAsync(Guid feedId, CancellationToken cancellationToken = default);
 
-    Task<FeedRetentionPolicy> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default);
+    Task<AzureDevOpsActionResult<FeedRetentionPolicy>> SetRetentionPolicyAsync(Guid feedId, FeedRetentionPolicy policy, CancellationToken cancellationToken = default);
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ArtifactsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ArtifactsTools.cs
@@ -1,7 +1,11 @@
+using System;
 using System.ComponentModel;
+using System.Collections.Generic;
+using System.IO;
 using Dotnet.AzureDevOps.Core.Artifacts;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
+using Dotnet.AzureDevOps.Core.Common;
 using ModelContextProtocol.Server;
 
 namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
@@ -13,131 +17,179 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
 public class ArtifactsTools
 {
     private static ArtifactsClient CreateClient(string organizationUrl, string projectName, string personalAccessToken)
-        => new(organizationUrl, projectName, personalAccessToken);
+        => new ArtifactsClient(organizationUrl, projectName, personalAccessToken);
 
     [McpServerTool, Description("Creates a new feed.")]
-    public static Task<Guid> CreateFeedAsync(string organizationUrl, string projectName, string personalAccessToken, FeedCreateOptions options)
+    public static async Task<Guid> CreateFeedAsync(string organizationUrl, string projectName, string personalAccessToken, FeedCreateOptions options)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateFeedAsync(options);
+        AzureDevOpsActionResult<Guid> result = await client.CreateFeedAsync(options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to create feed.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Updates an existing feed.")]
-    public static Task UpdateFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedUpdateOptions options)
+    public static async Task UpdateFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedUpdateOptions options)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.UpdateFeedAsync(feedId, options);
+        AzureDevOpsActionResult<bool> result = await client.UpdateFeedAsync(feedId, options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to update feed.");
     }
 
     [McpServerTool, Description("Retrieves a feed by identifier.")]
-    public static Task<Feed?> GetFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task<Feed?> GetFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetFeedAsync(feedId);
+        AzureDevOpsActionResult<Feed> result = await client.GetFeedAsync(feedId);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists all feeds in the project.")]
-    public static Task<IReadOnlyList<Feed>> ListFeedsAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<IReadOnlyList<Feed>> ListFeedsAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListFeedsAsync();
+        AzureDevOpsActionResult<IReadOnlyList<Feed>> result = await client.ListFeedsAsync();
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list feeds.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Deletes a feed by identifier.")]
-    public static Task DeleteFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task DeleteFeedAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeleteFeedAsync(feedId);
+        AzureDevOpsActionResult<bool> result = await client.DeleteFeedAsync(feedId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to delete feed.");
     }
 
     [McpServerTool, Description("Lists packages within a feed.")]
-    public static Task<IReadOnlyList<Package>> ListPackagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task<IReadOnlyList<Package>> ListPackagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListPackagesAsync(feedId);
+        AzureDevOpsActionResult<IReadOnlyList<Package>> result = await client.ListPackagesAsync(feedId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list packages.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Deletes a package from a feed.")]
-    public static Task DeletePackageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
+    public static async Task DeletePackageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeletePackageAsync(feedId, packageName, version);
+        AzureDevOpsActionResult<bool> result = await client.DeletePackageAsync(feedId, packageName, version);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to delete package.");
     }
 
     [McpServerTool, Description("Gets permissions for a feed.")]
-    public static Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task<IReadOnlyList<FeedPermission>> GetFeedPermissionsAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetFeedPermissionsAsync(feedId);
+        AzureDevOpsActionResult<IReadOnlyList<FeedPermission>> result = await client.GetFeedPermissionsAsync(feedId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to get feed permissions.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Creates a feed view.")]
-    public static Task<FeedView> CreateFeedViewAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedView view)
+    public static async Task<FeedView> CreateFeedViewAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedView view)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateFeedViewAsync(feedId, view);
+        AzureDevOpsActionResult<FeedView> result = await client.CreateFeedViewAsync(feedId, view);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to create feed view.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists feed views.")]
-    public static Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task<IReadOnlyList<FeedView>> ListFeedViewsAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListFeedViewsAsync(feedId);
+        AzureDevOpsActionResult<IReadOnlyList<FeedView>> result = await client.ListFeedViewsAsync(feedId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list feed views.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Deletes a feed view.")]
-    public static Task DeleteFeedViewAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string viewId)
+    public static async Task DeleteFeedViewAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string viewId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeleteFeedViewAsync(feedId, viewId);
+        AzureDevOpsActionResult<bool> result = await client.DeleteFeedViewAsync(feedId, viewId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to delete feed view.");
     }
 
     [McpServerTool, Description("Sets upstreaming behavior for a package.")]
-    public static Task SetUpstreamingBehaviorAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, UpstreamingBehavior behavior)
+    public static async Task SetUpstreamingBehaviorAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, UpstreamingBehavior behavior)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.SetUpstreamingBehaviorAsync(feedId, packageName, behavior);
+        AzureDevOpsActionResult<bool> result = await client.SetUpstreamingBehaviorAsync(feedId, packageName, behavior);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to set upstreaming behavior.");
     }
 
     [McpServerTool, Description("Gets upstreaming behavior for a package.")]
-    public static Task<UpstreamingBehavior> GetUpstreamingBehaviorAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName)
+    public static async Task<UpstreamingBehavior?> GetUpstreamingBehaviorAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetUpstreamingBehaviorAsync(feedId, packageName);
+        AzureDevOpsActionResult<UpstreamingBehavior> result = await client.GetUpstreamingBehaviorAsync(feedId, packageName);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 
     [McpServerTool, Description("Gets a specific package version.")]
-    public static Task<Package> GetPackageVersionAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
+    public static async Task<Package?> GetPackageVersionAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetPackageVersionAsync(feedId, packageName, version);
+        AzureDevOpsActionResult<Package> result = await client.GetPackageVersionAsync(feedId, packageName, version);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 
     [McpServerTool, Description("Updates metadata for a package version.")]
-    public static Task UpdatePackageVersionAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version, PackageVersionDetails details)
+    public static async Task UpdatePackageVersionAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version, PackageVersionDetails details)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.UpdatePackageVersionAsync(feedId, packageName, version, details);
+        AzureDevOpsActionResult<bool> result = await client.UpdatePackageVersionAsync(feedId, packageName, version, details);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to update package version.");
     }
 
     [McpServerTool, Description("Downloads a package version.")]
-    public static Task<Stream> DownloadPackageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
+    public static async Task<Stream> DownloadPackageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, string packageName, string version)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.DownloadPackageAsync(feedId, packageName, version);
+        AzureDevOpsActionResult<Stream> result = await client.DownloadPackageAsync(feedId, packageName, version);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to download package.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Gets the retention policy for a feed.")]
-    public static Task<FeedRetentionPolicy> GetRetentionPolicyAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
+    public static async Task<FeedRetentionPolicy> GetRetentionPolicyAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetRetentionPolicyAsync(feedId);
+        AzureDevOpsActionResult<FeedRetentionPolicy> result = await client.GetRetentionPolicyAsync(feedId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to get retention policy.");
+        return result.Value;
     }
 
     [McpServerTool, Description("Sets the retention policy for a feed.")]
-    public static Task<FeedRetentionPolicy> SetRetentionPolicyAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedRetentionPolicy policy)
+    public static async Task<FeedRetentionPolicy> SetRetentionPolicyAsync(string organizationUrl, string projectName, string personalAccessToken, Guid feedId, FeedRetentionPolicy policy)
     {
         ArtifactsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
-        return client.SetRetentionPolicyAsync(feedId, policy);
+        AzureDevOpsActionResult<FeedRetentionPolicy> result = await client.SetRetentionPolicyAsync(feedId, policy);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to set retention policy.");
+        return result.Value;
     }
 }

--- a/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
+++ b/test/integration.tests/Dotnet.AzureDevOps.Artifacts.IntegrationTests/DotnetAzureDevOpsArtifactsIntegrationTests.cs
@@ -1,8 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Dotnet.AzureDevOps.Core.Artifacts;
 using Dotnet.AzureDevOps.Core.Artifacts.Models;
 using Dotnet.AzureDevOps.Core.Artifacts.Options;
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Tests.Common;
 using Dotnet.AzureDevOps.Tests.Common.Attributes;
+using Xunit;
 
 namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
 {
@@ -11,7 +18,7 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
     public class DotnetAzureDevOpsArtifactsIntegrationTests : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
     {
         private readonly ArtifactsClient _artifactsClient;
-        private readonly List<Guid> _createdFeedIds = [];
+        private readonly List<Guid> _createdFeedIds = new List<Guid>();
         private readonly AzureDevOpsConfiguration _azureDevOpsConfiguration;
 
         public DotnetAzureDevOpsArtifactsIntegrationTests(IntegrationTestFixture fixture)
@@ -23,134 +30,180 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
         [Fact]
         public async Task FeedCrud_SucceedsAsync()
         {
-            var feedCreateOptions = new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"it-feed-{UtcStamp()}",
                 Description = "Created by integration test"
             };
 
-            Guid id = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid id = createResult.Value;
             _createdFeedIds.Add(id);
 
-            Feed? feed = await _artifactsClient.GetFeedAsync(id);
-            Assert.NotNull(feed);
-            Assert.Equal(feedCreateOptions.Name, feed!.Name);
+            AzureDevOpsActionResult<Feed> getResult = await _artifactsClient.GetFeedAsync(id);
+            Assert.True(getResult.IsSuccessful);
+            Feed feed = getResult.Value;
+            Assert.Equal(feedCreateOptions.Name, feed.Name);
 
-            await _artifactsClient.UpdateFeedAsync(id, new FeedUpdateOptions
+            FeedUpdateOptions updateOptions = new FeedUpdateOptions
             {
                 Description = "Updated via test"
-            });
+            };
+            AzureDevOpsActionResult<bool> updateResult = await _artifactsClient.UpdateFeedAsync(id, updateOptions);
+            Assert.True(updateResult.IsSuccessful);
 
-            feed = await _artifactsClient.GetFeedAsync(id);
-            Assert.Equal("Updated via test", feed!.Description);
+            getResult = await _artifactsClient.GetFeedAsync(id);
+            Assert.True(getResult.IsSuccessful);
+            Assert.Equal("Updated via test", getResult.Value.Description);
 
-            IReadOnlyList<Feed> list = await _artifactsClient.ListFeedsAsync();
-            Assert.Contains(list, f => f.Id == id);
+            AzureDevOpsActionResult<IReadOnlyList<Feed>> listResult = await _artifactsClient.ListFeedsAsync();
+            Assert.True(listResult.IsSuccessful);
+            Assert.Contains(listResult.Value, f => f.Id == id);
 
-            await _artifactsClient.DeleteFeedAsync(id);
+            AzureDevOpsActionResult<bool> deleteResult = await _artifactsClient.DeleteFeedAsync(id);
+            Assert.True(deleteResult.IsSuccessful);
             _createdFeedIds.Remove(id);
 
-            Feed? deleted = await _artifactsClient.GetFeedAsync(id);
-            Assert.Null(deleted);
+            AzureDevOpsActionResult<Feed> deletedResult = await _artifactsClient.GetFeedAsync(id);
+            Assert.False(deletedResult.IsSuccessful);
         }
 
         [Fact]
         public async Task ListPackages_Empty_ForNewFeed()
         {
-            Guid id = await _artifactsClient.CreateFeedAsync(new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"pkg-feed-{UtcStamp()}"
-            });
+            };
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid id = createResult.Value;
             _createdFeedIds.Add(id);
 
-            IReadOnlyList<Package> packages = await _artifactsClient.ListPackagesAsync(id);
-            Assert.Empty(packages);
+            AzureDevOpsActionResult<IReadOnlyList<Package>> packagesResult = await _artifactsClient.ListPackagesAsync(id);
+            Assert.True(packagesResult.IsSuccessful);
+            Assert.Empty(packagesResult.Value);
         }
 
         [Fact]
         public async Task FeedGetPermissions_SucceedsAsync()
         {
-            Guid feedId = await _artifactsClient.CreateFeedAsync(new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"perm-feed-{UtcStamp()}"
-            });
+            };
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid feedId = createResult.Value;
             _createdFeedIds.Add(feedId);
 
-            IReadOnlyList<FeedPermission> permissions = await _artifactsClient.GetFeedPermissionsAsync(feedId);
-            Assert.NotEmpty(permissions);
+            AzureDevOpsActionResult<IReadOnlyList<FeedPermission>> permissionsResult = await _artifactsClient.GetFeedPermissionsAsync(feedId);
+            Assert.True(permissionsResult.IsSuccessful);
+            Assert.NotEmpty(permissionsResult.Value);
         }
 
         [Fact]
         public async Task FeedViewsWorkflow_SucceedsAsync()
         {
-            Guid feedId = await _artifactsClient.CreateFeedAsync(new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"view-feed-{UtcStamp()}"
-            });
+            };
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid feedId = createResult.Value;
             _createdFeedIds.Add(feedId);
 
-            var view = new FeedView
+            FeedView view = new FeedView
             {
                 Name = $"view-{UtcStamp()}",
                 Visibility = "private",
                 Type = "release"
             };
 
-            FeedView created = await _artifactsClient.CreateFeedViewAsync(feedId, view);
-            IReadOnlyList<FeedView> views = await _artifactsClient.ListFeedViewsAsync(feedId);
-            Assert.Contains(views, v => v.Id == created.Id);
+            AzureDevOpsActionResult<FeedView> createViewResult = await _artifactsClient.CreateFeedViewAsync(feedId, view);
+            Assert.True(createViewResult.IsSuccessful);
+            FeedView created = createViewResult.Value;
 
-            await _artifactsClient.DeleteFeedViewAsync(feedId, created.Id);
+            AzureDevOpsActionResult<IReadOnlyList<FeedView>> listViewsResult = await _artifactsClient.ListFeedViewsAsync(feedId);
+            Assert.True(listViewsResult.IsSuccessful);
+            Assert.Contains(listViewsResult.Value, v => v.Id == created.Id);
 
-            IReadOnlyList<FeedView> afterDelete = await _artifactsClient.ListFeedViewsAsync(feedId);
-            Assert.DoesNotContain(afterDelete, v => v.Id == created.Id);
+            AzureDevOpsActionResult<bool> deleteViewResult = await _artifactsClient.DeleteFeedViewAsync(feedId, created.Id);
+            Assert.True(deleteViewResult.IsSuccessful);
+
+            listViewsResult = await _artifactsClient.ListFeedViewsAsync(feedId);
+            Assert.True(listViewsResult.IsSuccessful);
+            Assert.DoesNotContain(listViewsResult.Value, v => v.Id == created.Id);
         }
 
         [Fact]
         public async Task RetentionPolicyWorkflow_SucceedsAsync()
         {
             int days = 30;
-            Guid feedId = await _artifactsClient.CreateFeedAsync(new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"ret-feed-{UtcStamp()}"
-            });
+            };
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid feedId = createResult.Value;
             _createdFeedIds.Add(feedId);
 
-            FeedRetentionPolicy policy = await _artifactsClient.GetRetentionPolicyAsync(feedId);
-            var update = new FeedRetentionPolicy
+            AzureDevOpsActionResult<FeedRetentionPolicy> policyResult = await _artifactsClient.GetRetentionPolicyAsync(feedId);
+            Assert.True(policyResult.IsSuccessful);
+            FeedRetentionPolicy policy = policyResult.Value;
+            FeedRetentionPolicy update = new FeedRetentionPolicy
             {
-                AgeLimitInDays = policy?.AgeLimitInDays ?? days,
-                CountLimit = policy?.CountLimit ?? days,
-                DaysToKeepRecentlyDownloadedPackages = policy?.DaysToKeepRecentlyDownloadedPackages ?? days
+                AgeLimitInDays = policy.AgeLimitInDays ?? days,
+                CountLimit = policy.CountLimit ?? days,
+                DaysToKeepRecentlyDownloadedPackages = policy.DaysToKeepRecentlyDownloadedPackages ?? days
             };
 
-            FeedRetentionPolicy updated = await _artifactsClient.SetRetentionPolicyAsync(feedId, update);
-            Assert.NotNull(updated);
+            AzureDevOpsActionResult<FeedRetentionPolicy> updateResult = await _artifactsClient.SetRetentionPolicyAsync(feedId, update);
+            Assert.True(updateResult.IsSuccessful);
 
-            policy = await _artifactsClient.GetRetentionPolicyAsync(feedId);
-            Assert.Null(policy.AgeLimitInDays);
-            Assert.Equal(days, policy.CountLimit);
-            Assert.Equal(days, policy.DaysToKeepRecentlyDownloadedPackages);
+            policyResult = await _artifactsClient.GetRetentionPolicyAsync(feedId);
+            Assert.True(policyResult.IsSuccessful);
+            FeedRetentionPolicy updatedPolicy = policyResult.Value;
+            Assert.Null(updatedPolicy.AgeLimitInDays);
+            Assert.Equal(days, updatedPolicy.CountLimit);
+            Assert.Equal(days, updatedPolicy.DaysToKeepRecentlyDownloadedPackages);
         }
 
         [Fact]
         public async Task PackageAndUpstreaming_Methods_ReturnNotFoundAsync()
         {
-            Guid feedId = await _artifactsClient.CreateFeedAsync(new FeedCreateOptions
+            FeedCreateOptions feedCreateOptions = new FeedCreateOptions
             {
                 Name = $"pkgerr-feed-{UtcStamp()}"
-            });
+            };
+            AzureDevOpsActionResult<Guid> createResult = await _artifactsClient.CreateFeedAsync(feedCreateOptions);
+            Assert.True(createResult.IsSuccessful);
+            Guid feedId = createResult.Value;
             _createdFeedIds.Add(feedId);
 
             const string packageName = "non-existent";
             const string version = "1.0.0";
 
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.DeletePackageAsync(feedId, packageName, version));
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.GetPackageVersionAsync(feedId, packageName, version));
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.UpdatePackageVersionAsync(feedId, packageName, version, new PackageVersionDetails()));
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.DownloadPackageAsync(feedId, packageName, version));
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.SetUpstreamingBehaviorAsync(feedId, packageName, UpstreamingBehavior.Block));
-            await Assert.ThrowsAsync<HttpRequestException>(() => _artifactsClient.GetUpstreamingBehaviorAsync(feedId, packageName));
+            AzureDevOpsActionResult<bool> deletePackageResult = await _artifactsClient.DeletePackageAsync(feedId, packageName, version);
+            Assert.False(deletePackageResult.IsSuccessful);
+
+            AzureDevOpsActionResult<Package> getPackageResult = await _artifactsClient.GetPackageVersionAsync(feedId, packageName, version);
+            Assert.False(getPackageResult.IsSuccessful);
+
+            AzureDevOpsActionResult<bool> updatePackageResult = await _artifactsClient.UpdatePackageVersionAsync(feedId, packageName, version, new PackageVersionDetails());
+            Assert.False(updatePackageResult.IsSuccessful);
+
+            AzureDevOpsActionResult<Stream> downloadResult = await _artifactsClient.DownloadPackageAsync(feedId, packageName, version);
+            Assert.False(downloadResult.IsSuccessful);
+
+            AzureDevOpsActionResult<bool> setUpstreamResult = await _artifactsClient.SetUpstreamingBehaviorAsync(feedId, packageName, UpstreamingBehavior.Block);
+            Assert.False(setUpstreamResult.IsSuccessful);
+
+            AzureDevOpsActionResult<UpstreamingBehavior> getUpstreamResult = await _artifactsClient.GetUpstreamingBehaviorAsync(feedId, packageName);
+            Assert.False(getUpstreamResult.IsSuccessful);
         }
 
         /*────────── IAsyncLifetime ──────────*/
@@ -162,17 +215,14 @@ namespace Dotnet.AzureDevOps.Artifacts.IntegrationTests
             {
                 try
                 {
-                    await _artifactsClient.DeleteFeedAsync(id);
+                    AzureDevOpsActionResult<bool> result = await _artifactsClient.DeleteFeedAsync(id);
                 }
                 catch
                 {
-                    // Ignore errors during cleanup, as feeds may have been deleted already  
-                    // or there could be other issues that prevent deletion.  
                 }
             }
         }
 
-        private static string UtcStamp() =>
-            DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+        private static string UtcStamp() => DateTime.UtcNow.ToString("yyyyMMddHHmmss");
     }
 }


### PR DESCRIPTION
## Summary
- return AzureDevOpsActionResult from ArtifactsClient and interface
- update MCP server ArtifactsTools to surface AzureDevOpsActionResult
- adjust integration tests for new result pattern

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: 0% [Waiting for headers])*

------
https://chatgpt.com/codex/tasks/task_e_68923b7d69e0832c85799f19d9833eac