### PR TITLE
Use AzureDevOpsActionResult in overview clients

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IDashboardClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IDashboardClient.cs
@@ -1,10 +1,11 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Microsoft.TeamFoundation.Dashboards.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.Overview
 {
     public interface IDashboardClient
     {
-        Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(CancellationToken cancellationToken = default);
-        Task<Dashboard?> GetDashboardAsync(Guid dashboardId, string teamName, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<IReadOnlyList<Dashboard>>> ListDashboardsAsync(CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<Dashboard>> GetDashboardAsync(Guid dashboardId, string teamName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/ISummaryClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/ISummaryClient.cs
@@ -1,9 +1,10 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Microsoft.TeamFoundation.Core.WebApi;
 
 namespace Dotnet.AzureDevOps.Core.Overview
 {
     public interface ISummaryClient
     {
-        Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<TeamProject>> GetProjectSummaryAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/IWikiClient.cs
@@ -1,3 +1,4 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.Wiki.WebApi;
@@ -6,22 +7,22 @@ namespace Dotnet.AzureDevOps.Core.Overview
 {
     public interface IWikiClient
     {
-        Task<int?> CreateOrUpdatePageAsync(Guid wikiId, WikiPageUpdateOptions wikiPageUpdateOptions, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<int>> CreateOrUpdatePageAsync(Guid wikiId, WikiPageUpdateOptions wikiPageUpdateOptions, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default);
 
-        Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(Guid wikiId, WikiPagesBatchOptions pagesOptions, GitVersionDescriptor? versionDescriptor = null, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<IReadOnlyList<WikiPageDetail>>> ListPagesAsync(Guid wikiId, WikiPagesBatchOptions pagesOptions, GitVersionDescriptor? versionDescriptor = null, CancellationToken cancellationToken = default);
 
-        Task<string?> GetPageTextAsync(Guid wikiId, string path, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<string>> GetPageTextAsync(Guid wikiId, string path, CancellationToken cancellationToken = default);
 
-        Task<Guid> CreateWikiAsync(WikiCreateOptions wikiCreateOptions, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<Guid>> CreateWikiAsync(WikiCreateOptions wikiCreateOptions, CancellationToken cancellationToken = default);
 
-        Task<WikiPageResponse> DeletePageAsync(Guid wikiId, string path, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<WikiPageResponse>> DeletePageAsync(Guid wikiId, string path, GitVersionDescriptor gitVersionDescriptor, CancellationToken cancellationToken = default);
 
-        Task<WikiV2> DeleteWikiAsync(Guid wikiId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<WikiV2>> DeleteWikiAsync(Guid wikiId, CancellationToken cancellationToken = default);
 
-        Task<WikiPageResponse?> GetPageAsync(Guid wikiId, string path, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<WikiPageResponse>> GetPageAsync(Guid wikiId, string path, CancellationToken cancellationToken = default);
 
-        Task<WikiV2?> GetWikiAsync(Guid wikiId, CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<WikiV2>> GetWikiAsync(Guid wikiId, CancellationToken cancellationToken = default);
 
-        Task<IReadOnlyList<WikiV2>> ListWikisAsync(CancellationToken cancellationToken = default);
+        Task<AzureDevOpsActionResult<IReadOnlyList<WikiV2>>> ListWikisAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/SummaryClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/SummaryClient.cs
@@ -1,3 +1,4 @@
+using Dotnet.AzureDevOps.Core.Common;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
@@ -17,15 +18,16 @@ namespace Dotnet.AzureDevOps.Core.Overview
             _projectHttpClient = connection.GetClient<ProjectHttpClient>();
         }
 
-        public async Task<TeamProject?> GetProjectSummaryAsync(CancellationToken cancellationToken = default)
+        public async Task<AzureDevOpsActionResult<TeamProject>> GetProjectSummaryAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                return await _projectHttpClient.GetProject(_projectName, includeCapabilities: true, includeHistory: false, userState: null);
+                TeamProject project = await _projectHttpClient.GetProject(_projectName, includeCapabilities: true, includeHistory: false, userState: null);
+                return AzureDevOpsActionResult<TeamProject>.Success(project);
             }
-            catch (VssServiceException)
+            catch(Exception ex)
             {
-                return null;
+                return AzureDevOpsActionResult<TeamProject>.Failure(ex);
             }
         }
     }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/OverviewTools.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ComponentModel;
+using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.Overview;
 using Dotnet.AzureDevOps.Core.Overview.Options;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
@@ -25,86 +27,102 @@ public class OverviewTools
         => new(organizationUrl, projectName, personalAccessToken);
 
     [McpServerTool, Description("Creates a new wiki.")]
-    public static Task<Guid> CreateWikiAsync(string organizationUrl, string projectName, string personalAccessToken, WikiCreateOptions options)
+    public static async Task<Guid> CreateWikiAsync(string organizationUrl, string projectName, string personalAccessToken, WikiCreateOptions options)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateWikiAsync(options);
+        AzureDevOpsActionResult<Guid> result = await client.CreateWikiAsync(options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage);
+        return result.Value;
     }
 
     [McpServerTool, Description("Retrieves a wiki by identifier.")]
-    public static Task<WikiV2?> GetWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
+    public static async Task<WikiV2?> GetWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetWikiAsync(wikiId);
+        AzureDevOpsActionResult<WikiV2> result = await client.GetWikiAsync(wikiId);
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists wikis in the project.")]
-    public static Task<IReadOnlyList<WikiV2>> ListWikisAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<IReadOnlyList<WikiV2>> ListWikisAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListWikisAsync();
+        AzureDevOpsActionResult<IReadOnlyList<WikiV2>> result = await client.ListWikisAsync();
+        return result.Value;
     }
 
     [McpServerTool, Description("Deletes a wiki.")]
-    public static Task DeleteWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
+    public static async Task DeleteWikiAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeleteWikiAsync(wikiId);
+        AzureDevOpsActionResult<WikiV2> result = await client.DeleteWikiAsync(wikiId);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage);
     }
 
     [McpServerTool, Description("Creates or updates a wiki page.")]
-    public static Task<int?> CreateOrUpdatePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPageUpdateOptions options, GitVersionDescriptor version)
+    public static async Task<int?> CreateOrUpdatePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPageUpdateOptions options, GitVersionDescriptor version)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.CreateOrUpdatePageAsync(wikiId, options, version);
+        AzureDevOpsActionResult<int> result = await client.CreateOrUpdatePageAsync(wikiId, options, version);
+        return result.IsSuccessful ? result.Value : null;
     }
 
     [McpServerTool, Description("Retrieves a wiki page.")]
-    public static Task<WikiPageResponse?> GetPageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
+    public static async Task<WikiPageResponse?> GetPageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetPageAsync(wikiId, path);
+        AzureDevOpsActionResult<WikiPageResponse> result = await client.GetPageAsync(wikiId, path);
+        return result.Value;
     }
 
     [McpServerTool, Description("Deletes a wiki page.")]
-    public static Task DeletePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path, GitVersionDescriptor version)
+    public static async Task DeletePageAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path, GitVersionDescriptor version)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.DeletePageAsync(wikiId, path, version);
+        AzureDevOpsActionResult<WikiPageResponse> result = await client.DeletePageAsync(wikiId, path, version);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage);
     }
 
     [McpServerTool, Description("Lists pages in a wiki.")]
-    public static Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPagesBatchOptions options)
+    public static async Task<IReadOnlyList<WikiPageDetail>> ListPagesAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, WikiPagesBatchOptions options)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListPagesAsync(wikiId, options);
+        AzureDevOpsActionResult<IReadOnlyList<WikiPageDetail>> result = await client.ListPagesAsync(wikiId, options);
+        return result.Value;
     }
 
     [McpServerTool, Description("Gets wiki page content.")]
-    public static Task<string?> GetPageTextAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
+    public static async Task<string?> GetPageTextAsync(string organizationUrl, string projectName, string personalAccessToken, Guid wikiId, string path)
     {
         WikiClient client = CreateWikiClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetPageTextAsync(wikiId, path);
+        AzureDevOpsActionResult<string> result = await client.GetPageTextAsync(wikiId, path);
+        return result.Value;
     }
 
     [McpServerTool, Description("Retrieves project summary information.")]
-    public static Task<TeamProject?> GetProjectSummaryAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<TeamProject?> GetProjectSummaryAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
         SummaryClient client = CreateSummaryClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetProjectSummaryAsync();
+        AzureDevOpsActionResult<TeamProject> result = await client.GetProjectSummaryAsync();
+        return result.Value;
     }
 
     [McpServerTool, Description("Lists dashboards under the project.")]
-    public static Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<IReadOnlyList<Dashboard>> ListDashboardsAsync(string organizationUrl, string projectName, string personalAccessToken)
     {
         DashboardClient client = CreateDashboardClient(organizationUrl, projectName, personalAccessToken);
-        return client.ListDashboardsAsync();
+        AzureDevOpsActionResult<IReadOnlyList<Dashboard>> result = await client.ListDashboardsAsync();
+        return result.Value;
     }
 
     [McpServerTool, Description("Retrieves a dashboard by identifier and team name.")]
-    public static Task<Dashboard?> GetDashboardAsync(string organizationUrl, string projectName, string personalAccessToken, Guid dashboardId, string teamName)
+    public static async Task<Dashboard?> GetDashboardAsync(string organizationUrl, string projectName, string personalAccessToken, Guid dashboardId, string teamName)
     {
         DashboardClient client = CreateDashboardClient(organizationUrl, projectName, personalAccessToken);
-        return client.GetDashboardAsync(dashboardId, teamName);
+        AzureDevOpsActionResult<Dashboard> result = await client.GetDashboardAsync(dashboardId, teamName);
+        return result.Value;
     }
 }


### PR DESCRIPTION
## Summary
- return AzureDevOpsActionResult from overview clients for consistent success/failure reporting
- adapt tools and integration tests to new result pattern

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6892506cf224832ca3d75b166d4cce32