### PR TITLE
feat: add logging support to action results

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/Dotnet.AzureDevOps.Core.Common.csproj
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/Dotnet.AzureDevOps.Core.Common.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- inject ILogger into AzureDevOpsActionResult and emit structured logs
- reference Microsoft.Extensions.Logging.Abstractions for logging support

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68927628eaf4832c8fac9c203098c8af