### PR TITLE
Expose additional Azure DevOps APIs through tools

### DIFF
--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/BoardsTools.cs
@@ -407,5 +407,70 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools
             WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
             return client.GetWorkItemsBatchByIdsAsync(ids, expand, fields);
         }
+
+        [McpServerTool, Description("Assigns iterations to a team.")]
+        public static Task<AzureDevOpsActionResult<IReadOnlyList<TeamSettingsIteration>>> AssignIterationsAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            TeamContext teamContext,
+            IEnumerable<IterationAssignmentOptions> iterations)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.AssignIterationsAsync(teamContext, iterations);
+        }
+
+        [McpServerTool, Description("Creates iterations under the project.")]
+        public static Task<AzureDevOpsActionResult<IReadOnlyList<WorkItemClassificationNode>>> CreateIterationsAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            IEnumerable<IterationCreateOptions> iterations)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.CreateIterationsAsync(projectName, iterations);
+        }
+
+        [McpServerTool, Description("Creates a shared WIQL query.")]
+        public static Task<AzureDevOpsActionResult<bool>> CreateSharedQueryAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            string queryName, string wiql)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.CreateSharedQueryAsync(projectName, queryName, wiql);
+        }
+
+        [McpServerTool, Description("Deletes a shared WIQL query.")]
+        public static Task<AzureDevOpsActionResult<bool>> DeleteSharedQueryAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            string queryName)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.DeleteSharedQueryAsync(projectName, queryName);
+        }
+
+        [McpServerTool, Description("Executes a batch of work item requests.")]
+        public static Task<AzureDevOpsActionResult<IReadOnlyList<WitBatchResponse>>> ExecuteBatchAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            IEnumerable<WitBatchRequest> requests)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.ExecuteBatchAsync(requests);
+        }
+
+        [McpServerTool, Description("Updates multiple work items in a batch.")]
+        public static Task<AzureDevOpsActionResult<IReadOnlyList<WitBatchResponse>>> UpdateWorkItemsBatchAsync(
+            string organizationUrl, string projectName, string personalAccessToken,
+            IEnumerable<(int id, WorkItemCreateOptions options)> updates,
+            bool suppressNotifications = true,
+            bool bypassRules = false)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.UpdateWorkItemsBatchAsync(updates, suppressNotifications, bypassRules);
+        }
+
+        [McpServerTool, Description("Checks whether the current process is system-defined.")]
+        public static Task<AzureDevOpsActionResult<bool>> IsSystemProcessAsync(
+            string organizationUrl, string projectName, string personalAccessToken)
+        {
+            WorkItemsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+            return client.IsSystemProcessAsync();
+        }
     }
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/CommonTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/CommonTools.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel;
+using System.Net;
+using Dotnet.AzureDevOps.Core.Common;
+using ModelContextProtocol.Server;
+
+namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
+
+[McpServerToolType]
+public static class CommonTools
+{
+    [McpServerTool, Description("Dumps an exception to a full string representation.")]
+    public static string DumpFullException(Exception exception, bool includeData = true)
+        => exception.DumpFullException(includeData);
+
+    [McpServerTool, Description("Creates a failure result from an HTTP status code.")]
+    public static AzureDevOpsActionResult<string> FailureFromStatusCode(int statusCode, string? errorMessage = null)
+        => AzureDevOpsActionResult<string>.Failure((HttpStatusCode)statusCode, errorMessage);
+
+    [McpServerTool, Description("Creates a failure result from an exception message.")]
+    public static AzureDevOpsActionResult<string> FailureFromException(string message)
+        => AzureDevOpsActionResult<string>.Failure(new Exception(message));
+
+    [McpServerTool, Description("Creates a failure result from an error message.")]
+    public static AzureDevOpsActionResult<string> FailureFromMessage(string errorMessage)
+        => AzureDevOpsActionResult<string>.Failure(errorMessage);
+}

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/PipelinesTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/PipelinesTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Collections.Generic;
 using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.Pipelines;
 using Dotnet.AzureDevOps.Core.Pipelines.Options;
@@ -92,6 +93,55 @@ public class PipelinesTools
     {
         PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
         return client.DeletePipelineAsync(definitionId);
+    }
+
+    [McpServerTool, Description("Lists build definitions with advanced filters.")]
+    public static Task<AzureDevOpsActionResult<IReadOnlyList<BuildDefinitionReference>>> ListDefinitionsAsync(string organizationUrl, string projectName, string personalAccessToken, BuildDefinitionListOptions options)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListDefinitionsAsync(options);
+    }
+
+    [McpServerTool, Description("Gets definition revision history.")]
+    public static Task<AzureDevOpsActionResult<List<BuildDefinitionRevision>>> GetDefinitionRevisionsAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetDefinitionRevisionsAsync(definitionId);
+    }
+
+    [McpServerTool, Description("Retrieves build logs.")]
+    public static Task<AzureDevOpsActionResult<List<BuildLog>>> GetLogsAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetLogsAsync(buildId);
+    }
+
+    [McpServerTool, Description("Retrieves lines from a build log.")]
+    public static Task<AzureDevOpsActionResult<List<string>>> GetLogLinesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, int logId, int? startLine = null, int? endLine = null)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetLogLinesAsync(buildId, logId, startLine, endLine);
+    }
+
+    [McpServerTool, Description("Gets changes associated with a build.")]
+    public static Task<AzureDevOpsActionResult<List<Change>>> GetChangesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string? continuationToken = null, int top = 100, bool includeSourceChange = false)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetChangesAsync(buildId, continuationToken, top, includeSourceChange);
+    }
+
+    [McpServerTool, Description("Retrieves the build report metadata.")]
+    public static Task<AzureDevOpsActionResult<BuildReportMetadata>> GetBuildReportAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetBuildReportAsync(buildId);
+    }
+
+    [McpServerTool, Description("Updates the state of a build stage.")]
+    public static Task<AzureDevOpsActionResult<bool>> UpdateBuildStageAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string stageName, StageUpdateType status, bool forceRetryAllJobs = false)
+    {
+        PipelinesClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.UpdateBuildStageAsync(buildId, stageName, status, forceRetryAllJobs);
     }
 }
 

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ProjectSettingsTools.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Dotnet.AzureDevOps.Core.Common;
@@ -99,5 +100,25 @@ public static class ProjectSettingsTools
         AzureDevOpsActionResult<bool> result = await client.DeleteProjectAsync(projectId);
         if(!result.IsSuccessful)
             throw new InvalidOperationException(result.ErrorMessage ?? "Failed to delete project.");
+    }
+
+    [McpServerTool, Description("Lists all teams in the organization.")]
+    public static async Task<IReadOnlyList<WebApiTeam>> GetAllTeamsAsync(string organizationUrl, string projectName, string personalAccessToken)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        AzureDevOpsActionResult<List<WebApiTeam>> result = await client.GetAllTeamsAsync();
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to list teams.");
+        return result.Value ?? [];
+    }
+
+    [McpServerTool, Description("Retrieves a project by name.")]
+    public static async Task<TeamProject?> GetProjectAsync(string organizationUrl, string projectName, string personalAccessToken, string targetProjectName)
+    {
+        ProjectSettingsClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        AzureDevOpsActionResult<TeamProject> result = await client.GetProjectAsync(targetProjectName);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
     }
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ReposTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/ReposTools.cs
@@ -389,4 +389,33 @@ public class ReposTools
             throw new InvalidOperationException(result.ErrorMessage ?? "Failed to get latest commits.");
         return result.Value ?? [];
     }
+
+    [McpServerTool, Description("Adds a reviewer to a pull request.")]
+    public static async Task AddReviewerAsync(string organizationUrl, string projectName, string personalAccessToken, string repositoryId, int pullRequestId, (string localId, string name) reviewer)
+    {
+        AzureDevOpsActionResult<bool> result = await CreateClient(organizationUrl, projectName, personalAccessToken)
+            .AddReviewerAsync(repositoryId, pullRequestId, reviewer);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to add reviewer.");
+    }
+
+    [McpServerTool, Description("Commits a new file to a repository.")]
+    public static async Task<string> CommitAddFileAsync(string organizationUrl, string projectName, string personalAccessToken, FileCommitOptions options)
+    {
+        AzureDevOpsActionResult<string> result = await CreateClient(organizationUrl, projectName, personalAccessToken)
+            .CommitAddFileAsync(options);
+        if(!result.IsSuccessful)
+            throw new InvalidOperationException(result.ErrorMessage ?? "Failed to commit file.");
+        return result.Value;
+    }
+
+    [McpServerTool, Description("Retrieves a repository by identifier.")]
+    public static async Task<GitRepository?> GetRepositoryAsync(string organizationUrl, string projectName, string personalAccessToken, Guid repositoryId)
+    {
+        AzureDevOpsActionResult<GitRepository> result = await CreateClient(organizationUrl, projectName, personalAccessToken)
+            .GetRepositoryAsync(repositoryId);
+        if(!result.IsSuccessful)
+            return null;
+        return result.Value;
+    }
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/TestPlansTools.cs
@@ -3,6 +3,8 @@ using Dotnet.AzureDevOps.Core.Common;
 using Dotnet.AzureDevOps.Core.TestPlans;
 using Dotnet.AzureDevOps.Core.TestPlans.Options;
 using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
+using Microsoft.VisualStudio.Services.TestResults.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
 using ModelContextProtocol.Server;
 
 namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
@@ -92,5 +94,19 @@ public class TestPlansTools
         if(!result.IsSuccessful)
             return null;
         return result.Value;
+    }
+
+    [McpServerTool, Description("Lists test cases in a suite.")]
+    public static Task<AzureDevOpsActionResult<PagedList<TestCase>>> ListTestCasesAsync(string organizationUrl, string projectName, string personalAccessToken, int testPlanId, int testSuiteId)
+    {
+        TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.ListTestCasesAsync(testPlanId, testSuiteId);
+    }
+
+    [McpServerTool, Description("Gets test results for a build.")]
+    public static Task<AzureDevOpsActionResult<TestResultsDetails>> GetTestResultsForBuildAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    {
+        TestPlansClient client = CreateClient(organizationUrl, projectName, personalAccessToken);
+        return client.GetTestResultsForBuildAsync(projectName, buildId);
     }
 }


### PR DESCRIPTION
## Summary
- surface missing repository operations: add reviewer, commit file, fetch repo
- expose board utilities for iterations, queries, batches, and process detection
- add pipeline methods for definitions, logs, changes, reports, and stage updates
- include project/team lookup APIs and test plan helpers
- provide CommonTools for exception dumps and failure results

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689282a29f00832c9373759fa79eb4e5