### PR TITLE
feat: add structured logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="OpenTelemetry" />

--- a/src/Dotnet.AzureDevOps.Mcp.Server/McpServer/HostingExtensions.Logging.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/McpServer/HostingExtensions.Logging.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +14,19 @@ internal static class HostingExtensionsLogging
 
         builder.Logging.ClearProviders();
         builder.Logging.AddConsole();
+
+        if (settings.EnableApplicationInsights &&
+            !string.IsNullOrWhiteSpace(settings.ApplicationInsightsConnectionString))
+        {
+            builder.Logging.AddApplicationInsights(config =>
+            {
+                config.ConnectionString = settings.ApplicationInsightsConnectionString;
+            }, _ => { });
+        }
+
         builder.Logging.SetMinimumLevel(settings.LogLevel);
 
         return builder;
     }
 }
+

--- a/src/Dotnet.AzureDevOps.Mcp.Server/McpServer/McpServerSettings.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/McpServer/McpServerSettings.cs
@@ -8,5 +8,11 @@ public sealed record McpServerSettings
 
     public bool EnableOpenTelemetry { get; init; } = true;
 
+    public bool EnableApplicationInsights { get; init; }
+        = false;
+
+    public string? ApplicationInsightsConnectionString { get; init; }
+        = null;
+
     public int Port { get; init; } = 5050;
 }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/appsettings.json
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/appsettings.json
@@ -8,6 +8,8 @@
     "McpServer": {
         "Port": 5050,
         "EnableOpenTelemetry": true,
+        "EnableApplicationInsights": false,
+        "ApplicationInsightsConnectionString": "",
         "LogLevel": "Trace"
     }
 }


### PR DESCRIPTION
## Summary
- integrate Microsoft.Extensions.Logging.AppInsights
- add configurable logging settings for console & Application Insights

## Testing
- `~/.dotnet/dotnet build src/Dotnet.AzureDevOps.Mcp.Server/Dotnet.AzureDevOps.Mcp.Server.csproj`
- `~/.dotnet/dotnet test` *(fails: Section 'AZURE_DEVOPS_ORG' not found in configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689338e03368832c9a0e7025e0217db5