### PR TITLE
Pass logger to AzureDevOpsActionResult

### DIFF
--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Common/AzureDevOpsActionResult.cs
@@ -27,25 +27,25 @@ public class AzureDevOpsActionResult<T>
         ErrorMessage = errorMessage;
     }
 
-    public static AzureDevOpsActionResult<T> Success(T value, ILogger<AzureDevOpsActionResult<T>>? logger = null)
+    public static AzureDevOpsActionResult<T> Success(T value, ILogger? logger = null)
     {
         logger?.LogInformation("Azure DevOps action completed successfully.");
         return new(true, value, null);
     }
 
-    public static AzureDevOpsActionResult<T> Failure(HttpStatusCode statusCode, string? errorMessage = null, ILogger<AzureDevOpsActionResult<T>>? logger = null)
+    public static AzureDevOpsActionResult<T> Failure(HttpStatusCode statusCode, string? errorMessage = null, ILogger? logger = null)
     {
         logger?.LogError("Request failed with status code {StatusCode}. {ErrorMessage}", (int)statusCode, errorMessage);
         return new(false, default!, $"http response status code: {(int)statusCode}, errorMessage: {errorMessage}");
     }
 
-    public static AzureDevOpsActionResult<T> Failure(Exception exception, ILogger<AzureDevOpsActionResult<T>>? logger = null)
+    public static AzureDevOpsActionResult<T> Failure(Exception exception, ILogger? logger = null)
     {
         logger?.LogError(exception, "Request failed with an exception.");
         return new(false, default!, $"the request ended raising an error exception: {exception.DumpFullException()}");
     }
 
-    public static AzureDevOpsActionResult<T> Failure(string errorMessage, ILogger<AzureDevOpsActionResult<T>>? logger = null)
+    public static AzureDevOpsActionResult<T> Failure(string errorMessage, ILogger? logger = null)
     {
         logger?.LogError("Request failed with error: {ErrorMessage}", errorMessage);
         return new(false, default!, errorMessage);

--- a/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/DashboardClient.cs
+++ b/src/Dotnet.AzureDevOps.Core/Dotnet.AzureDevOps.Core.Overview/DashboardClient.cs
@@ -1,4 +1,6 @@
 using Dotnet.AzureDevOps.Core.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.TeamFoundation.Core.WebApi.Types;
 using Microsoft.TeamFoundation.Dashboards.WebApi;
 using Microsoft.VisualStudio.Services.Common;
@@ -10,10 +12,12 @@ namespace Dotnet.AzureDevOps.Core.Overview
     {
         private readonly string _projectName;
         private readonly DashboardHttpClient _dashboardHttpClient;
+        private readonly ILogger _logger;
 
-        public DashboardClient(string organizationUrl, string projectName, string personalAccessToken)
+        public DashboardClient(string organizationUrl, string projectName, string personalAccessToken, ILogger? logger = null)
         {
             _projectName = projectName;
+            _logger = logger ?? NullLogger.Instance;
             var credentials = new VssBasicCredential(string.Empty, personalAccessToken);
             var connection = new VssConnection(new Uri(organizationUrl), credentials);
             _dashboardHttpClient = connection.GetClient<DashboardHttpClient>();
@@ -26,11 +30,11 @@ namespace Dotnet.AzureDevOps.Core.Overview
                 TeamContext teamContext = new TeamContext(_projectName);
                 List<Dashboard> group = await _dashboardHttpClient.GetDashboardsByProjectAsync(teamContext, cancellationToken: cancellationToken);
                 IReadOnlyList<Dashboard> dashboards = group?.Where(d => d != null).ToList() ?? new List<Dashboard>();
-                return AzureDevOpsActionResult<IReadOnlyList<Dashboard>>.Success(dashboards);
+                return AzureDevOpsActionResult<IReadOnlyList<Dashboard>>.Success(dashboards, _logger);
             }
             catch(Exception ex)
             {
-                return AzureDevOpsActionResult<IReadOnlyList<Dashboard>>.Failure(ex);
+                return AzureDevOpsActionResult<IReadOnlyList<Dashboard>>.Failure(ex, _logger);
             }
         }
 
@@ -40,11 +44,11 @@ namespace Dotnet.AzureDevOps.Core.Overview
             {
                 TeamContext teamContext = new TeamContext(_projectName, teamName);
                 Dashboard dashboard = await _dashboardHttpClient.GetDashboardAsync(teamContext, dashboardId, cancellationToken: cancellationToken);
-                return AzureDevOpsActionResult<Dashboard>.Success(dashboard);
+                return AzureDevOpsActionResult<Dashboard>.Success(dashboard, _logger);
             }
             catch(Exception ex)
             {
-                return AzureDevOpsActionResult<Dashboard>.Failure(ex);
+                return AzureDevOpsActionResult<Dashboard>.Failure(ex, _logger);
             }
         }
     }

--- a/src/Dotnet.AzureDevOps.Mcp.Server/Tools/PipelinesTools.cs
+++ b/src/Dotnet.AzureDevOps.Mcp.Server/Tools/PipelinesTools.cs
@@ -6,6 +6,8 @@ using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
 using ModelContextProtocol.Server;
 
+using Microsoft.Extensions.Logging;
+
 namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
 
 /// <summary>
@@ -14,132 +16,132 @@ namespace Dotnet.AzureDevOps.Mcp.Server.Tools;
 [McpServerToolType]
 public class PipelinesTools
 {
-    private static PipelinesClient CreateClient(string organizationUrl, string projectName, string personalAccessToken)
-        => new PipelinesClient(organizationUrl, projectName, personalAccessToken);
+    private static PipelinesClient CreateClient(string organizationUrl, string projectName, string personalAccessToken, ILogger? logger = null)
+        => new PipelinesClient(organizationUrl, projectName, personalAccessToken, logger);
 
     [McpServerTool, Description("Queues a new build run.")]
-    public static async Task<int> QueueRunAsync(string organizationUrl, string projectName, string personalAccessToken, BuildQueueOptions options)
+    public static async Task<int> QueueRunAsync(string organizationUrl, string projectName, string personalAccessToken, BuildQueueOptions options, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .QueueRunAsync(options)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Gets a build run by id.")]
-    public static async Task<Build> GetRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    public static async Task<Build> GetRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetRunAsync(buildId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Lists build runs.")]
-    public static async Task<IReadOnlyList<Build>> ListRunsAsync(string organizationUrl, string projectName, string personalAccessToken, BuildListOptions options)
+    public static async Task<IReadOnlyList<Build>> ListRunsAsync(string organizationUrl, string projectName, string personalAccessToken, BuildListOptions options, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .ListRunsAsync(options)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Cancels a running build.")]
-    public static async Task<bool> CancelRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, TeamProjectReference project)
+    public static async Task<bool> CancelRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, TeamProjectReference project, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .CancelRunAsync(buildId, project)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Retries a completed build run.")]
-    public static async Task<int> RetryRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    public static async Task<int> RetryRunAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .RetryRunAsync(buildId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Downloads the console log for a build.")]
-    public static async Task<string> DownloadConsoleLogAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    public static async Task<string> DownloadConsoleLogAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .DownloadConsoleLogAsync(buildId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Creates a new pipeline definition.")]
-    public static async Task<int> CreatePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, PipelineCreateOptions options)
+    public static async Task<int> CreatePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, PipelineCreateOptions options, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .CreatePipelineAsync(options)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Retrieves a pipeline definition.")]
-    public static async Task<BuildDefinition> GetPipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId)
+    public static async Task<BuildDefinition> GetPipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetPipelineAsync(definitionId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Lists pipeline definitions.")]
-    public static async Task<IReadOnlyList<BuildDefinitionReference>> ListPipelinesAsync(string organizationUrl, string projectName, string personalAccessToken)
+    public static async Task<IReadOnlyList<BuildDefinitionReference>> ListPipelinesAsync(string organizationUrl, string projectName, string personalAccessToken, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .ListPipelinesAsync()).EnsureSuccess();
     }
 
     [McpServerTool, Description("Updates a pipeline definition.")]
-    public static async Task<bool> UpdatePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId, PipelineUpdateOptions options)
+    public static async Task<bool> UpdatePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId, PipelineUpdateOptions options, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .UpdatePipelineAsync(definitionId, options)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Deletes a pipeline definition.")]
-    public static async Task<bool> DeletePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId)
+    public static async Task<bool> DeletePipelineAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .DeletePipelineAsync(definitionId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Lists build definitions with advanced filters.")]
-    public static async Task<IReadOnlyList<BuildDefinitionReference>> ListDefinitionsAsync(string organizationUrl, string projectName, string personalAccessToken, BuildDefinitionListOptions options)
+    public static async Task<IReadOnlyList<BuildDefinitionReference>> ListDefinitionsAsync(string organizationUrl, string projectName, string personalAccessToken, BuildDefinitionListOptions options, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .ListDefinitionsAsync(options)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Gets definition revision history.")]
-    public static async Task<List<BuildDefinitionRevision>> GetDefinitionRevisionsAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId)
+    public static async Task<List<BuildDefinitionRevision>> GetDefinitionRevisionsAsync(string organizationUrl, string projectName, string personalAccessToken, int definitionId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetDefinitionRevisionsAsync(definitionId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Retrieves build logs.")]
-    public static async Task<List<BuildLog>> GetLogsAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    public static async Task<List<BuildLog>> GetLogsAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetLogsAsync(buildId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Retrieves lines from a build log.")]
-    public static async Task<List<string>> GetLogLinesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, int logId, int? startLine = null, int? endLine = null)
+    public static async Task<List<string>> GetLogLinesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, int logId, int? startLine = null, int? endLine = null, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetLogLinesAsync(buildId, logId, startLine, endLine)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Gets changes associated with a build.")]
-    public static async Task<List<Change>> GetChangesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string? continuationToken = null, int top = 100, bool includeSourceChange = false)
+    public static async Task<List<Change>> GetChangesAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string? continuationToken = null, int top = 100, bool includeSourceChange = false, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetChangesAsync(buildId, continuationToken, top, includeSourceChange)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Retrieves the build report metadata.")]
-    public static async Task<BuildReportMetadata> GetBuildReportAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId)
+    public static async Task<BuildReportMetadata> GetBuildReportAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .GetBuildReportAsync(buildId)).EnsureSuccess();
     }
 
     [McpServerTool, Description("Updates the state of a build stage.")]
-    public static async Task<bool> UpdateBuildStageAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string stageName, StageUpdateType status, bool forceRetryAllJobs = false)
+    public static async Task<bool> UpdateBuildStageAsync(string organizationUrl, string projectName, string personalAccessToken, int buildId, string stageName, StageUpdateType status, bool forceRetryAllJobs = false, ILogger? logger = null)
     {
-        return (await CreateClient(organizationUrl, projectName, personalAccessToken)
+        return (await CreateClient(organizationUrl, projectName, personalAccessToken, logger)
             .UpdateBuildStageAsync(buildId, stageName, status, forceRetryAllJobs)).EnsureSuccess();
     }
 }


### PR DESCRIPTION
## Summary
- propagate ILogger through PipelinesClient and DashboardClient so AzureDevOpsActionResult records messages
- allow PipelinesTools methods to accept and forward ILogger instances
- simplify AzureDevOpsActionResult to use generic ILogger interface

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689331870e08832cad819a09e4a3e7a6